### PR TITLE
Fix RA flag mask and add round-trip test

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -70,7 +70,7 @@ void Message::decode_hdr(const char* buffer)
     m_aa = fields & AA_MASK;
     m_tc = fields & TC_MASK;
     m_rd = fields & RD_MASK;
-    m_ra = fields & RA_MASK;
+    m_ra = (fields & RA_MASK) >> 7;
 
     m_qdCount = get16bits(buffer);
     m_anCount = get16bits(buffer);
@@ -89,6 +89,7 @@ void Message::code_hdr(char* buffer)
     fields += (m_aa << 10);
     fields += (m_tc << 9);
     fields += (m_rd << 8);
+    fields += (m_ra << 7);
     put16bits(buffer, fields);
 
     put16bits(buffer, m_qdCount);

--- a/src/message.hpp
+++ b/src/message.hpp
@@ -100,7 +100,7 @@ private:
     static const uint AA_MASK = 0x0400;
     static const uint TC_MASK = 0x0200;
     static const uint RD_MASK = 0x0100;
-    static const uint RA_MASK = 0x8000;
+    static const uint RA_MASK = 0x0080;
     static const uint RCODE_MASK = 0x000F;
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,3 +24,12 @@ if(WIN32)
 else()
         target_link_libraries(fonctionalTest Dnscommunication pthread)
 endif()
+
+add_executable(messageTest "message_test.cpp" )
+set_property(TARGET messageTest PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
+
+if(WIN32)
+        target_link_libraries(messageTest Dnscommunication)
+else()
+        target_link_libraries(messageTest Dnscommunication pthread)
+endif()

--- a/tests/message_test.cpp
+++ b/tests/message_test.cpp
@@ -1,0 +1,34 @@
+#include "message.hpp"
+#include <cassert>
+
+using namespace dns;
+
+struct MessageHdrTest : public Message {
+    MessageHdrTest() : Message(Message::Response) {}
+
+    int code(char*) override { return 0; }
+    void decode(const char*, int) override {}
+
+    using Message::code_hdr;
+    using Message::decode_hdr;
+
+    void setRA(uint v) { m_ra = v; }
+    uint getRA() const { return m_ra; }
+};
+
+int main() {
+    char buffer[12] = {};
+    char* wptr = buffer;
+
+    MessageHdrTest msg;
+    msg.setRA(1);
+    msg.code_hdr(wptr);
+
+    const char* rptr = buffer;
+    MessageHdrTest result;
+    result.decode_hdr(rptr);
+
+    assert(result.getRA() == 1);
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- correct RA_MASK constant and wire RA bit encoding/decoding
- add unit test exercising RA bit round-trip through header encode/decode

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/tests/messageTest`
- `./build/tests/utilsTest`
- `./build/tests/testsDns`
- `./build/tests/fonctionalTest --help`


------
https://chatgpt.com/codex/tasks/task_e_68b023ba13d48325abacec53e8ca00d5