### PR TITLE
Add detailed debug logging for DNS communication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(Dnscommunication VERSION 0.0.0 LANGUAGES CXX C)
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_STANDARD 17)
 
+option(DNS_ENABLE_LOGGING "Enable debug logging output" ON)
+
 IF (WIN32)
     set(CMAKE_CXX_FLAGS_RELEASE "-MT -O1 -Ob0")
     set(CMAKE_C_FLAGS_RELEASE "-MT -O1 -Ob0")
@@ -30,6 +32,9 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY
   MSVC_RUNTIME_LIBRARY "MultiThreaded")
 target_link_libraries(${PROJECT_NAME} )
 target_include_directories(${PROJECT_NAME} PUBLIC src)
+if(DNS_ENABLE_LOGGING)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC DNS_ENABLE_LOGGING)
+endif()
 if(WIN32)
 else()
 	target_link_libraries(${PROJECT_NAME} pthread)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <algorithm>
+#include <chrono>
 #include <cctype>
 #include <string_view>
 #include <errno.h>
@@ -12,6 +13,7 @@
 #endif
 
 #include "client.hpp"
+#include "debugLog.hpp"
 
 using namespace std;
 using namespace dns;
@@ -38,8 +40,32 @@ void Client::sendMessage(const std::string& msg)
     query.setNsCount(0);
     query.setArCount(0);
 
+    dns::debug::log(
+        "Client::sendMessage",
+        "Preparing transmission to DNS server " + m_dnsServerAdd + ":" +
+            std::to_string(m_port));
+
     if(!msg.empty())
+    {
+        dns::debug::log(
+            "Client::sendMessage",
+            "Queueing new payload of " +
+                std::to_string(static_cast<unsigned long long>(msg.size())) +
+                " bytes");
         setMsg(msg);
+    }
+    else
+    {
+        dns::debug::log("Client::sendMessage",
+                        "No new payload provided; sending queued fragments");
+    }
+
+    dns::debug::log(
+        "Client::sendMessage",
+        "Outbound fragment queue contains " +
+            std::to_string(static_cast<unsigned long long>(m_msgQueue.size())) +
+            " item(s); awaiting more fragments=" +
+            (m_moreMsgToGet ? std::string("true") : std::string("false")));
 
     struct sockaddr_in serv_addr;
     fd_set read_fds;
@@ -59,26 +85,64 @@ void Client::sendMessage(const std::string& msg)
     serv_addr.sin_addr.s_addr = inet_addr( m_dnsServerAdd.c_str() );
 #endif
 
+    dns::debug::log("Client::sendMessage",
+                    "UDP socket created; attempting connection test via connect()");
+
     if (connect(sockfd, (struct sockaddr*) &serv_addr, sizeof(serv_addr)) < 0)
     {
-        // std::cout << "Error occurred during connection" << std::endl;
+        dns::debug::log("Client::sendMessage",
+                        "connect() failed; continuing with sendto/recvfrom");
+    }
+    else
+    {
+        dns::debug::log("Client::sendMessage",
+                        "connect() succeeded for diagnostic connection check");
     }
 
+    size_t iteration = 0;
+    auto sessionStart = std::chrono::steady_clock::now();
     while(!m_msgQueue.empty() || m_moreMsgToGet)
     {
+        ++iteration;
+        auto iterationStart = std::chrono::steady_clock::now();
+        dns::debug::log(
+            "Client::sendMessage",
+            "Iteration " + std::to_string(iteration) +
+                ": fragments remaining before dequeue=" +
+                std::to_string(
+                    static_cast<unsigned long long>(m_msgQueue.size())) +
+                ", awaiting more=" +
+                (m_moreMsgToGet ? std::string("true") : std::string("false")));
+
         std::string qname;
         if(!m_msgQueue.empty())
         {
-            std::string subdomain = addDotEvery62Chars(m_msgQueue.front());
+            const std::string fragmentHex = m_msgQueue.front();
+            std::string preview = fragmentHex.substr(0, 60);
+            if(fragmentHex.size() > preview.size())
+                preview += "...";
+
+            std::string subdomain = addDotEvery62Chars(fragmentHex);
             qname += subdomain;
             qname += ".";
             m_msgQueue.pop();
+
+            dns::debug::log(
+                "Client::sendMessage",
+                "Dequeued fragment hex-length=" +
+                    std::to_string(
+                        static_cast<unsigned long long>(fragmentHex.size())) +
+                    " preview='" + preview + "'");
         }
         else
         {
             qname = "admin";
             qname += generateRandomString(8);
             qname += ".";
+
+            dns::debug::log("Client::sendMessage",
+                            "No fragment ready; issuing keep-alive query '" +
+                                qname + "'");
         }
 
         qname += m_domainToResolve;
@@ -88,13 +152,28 @@ void Client::sendMessage(const std::string& msg)
 
         nbytes = query.code(buffer);
 
+        dns::debug::log(
+            "Client::sendMessage",
+            "Encoded query length=" + std::to_string(nbytes) +
+                " bytes for QNAME '" + qname + "'");
+
         int t_len = sizeof(serv_addr);
         int req = sendto(sockfd, buffer, nbytes, 0, (struct sockaddr*) &serv_addr, t_len);
         if(req < 1)
         {
-            // std::cout << "Error occurred during sending" << std::endl;
+            dns::debug::log("Client::sendMessage",
+                            "sendto() failed with return value " +
+                                std::to_string(req));
             break;
         }
+
+        auto afterSend = std::chrono::steady_clock::now();
+        dns::debug::log(
+            "Client::sendMessage",
+            "Sent " + std::to_string(req) + " bytes to " + m_dnsServerAdd +
+                ":" + std::to_string(m_port) + " (" +
+                dns::debug::formatDuration(afterSend - iterationStart) +
+                " since iteration start)");
 
         FD_SET(sockfd, &read_fds);
         struct timeval timeout;
@@ -102,16 +181,25 @@ void Client::sendMessage(const std::string& msg)
         timeout.tv_usec = 10;
         int selection = select(sockfd + 1, &read_fds, NULL, NULL, &timeout);
 
+        auto afterSelect = std::chrono::steady_clock::now();
+
         if(selection < 1)
         {
             if (selection != -1)
             {
                 FD_CLR(sockfd, &read_fds);
+                dns::debug::log(
+                    "Client::sendMessage",
+                    "select() timeout after " +
+                        dns::debug::formatDuration(afterSelect - afterSend));
                 break;
             }
             else
             {
-                // std::cout << "Error: select didn't work properly" << std::endl;
+                dns::debug::log("Client::sendMessage",
+                                "select() returned error after " +
+                                    dns::debug::formatDuration(afterSelect -
+                                                               afterSend));
                 break;
             }
         }
@@ -122,14 +210,60 @@ void Client::sendMessage(const std::string& msg)
         int received = recvfrom(sockfd, buffer, BUFFER_SIZE, 0, (struct sockaddr*) &serv_addr, (socklen_t*) &t_len);
 #endif
 
+        auto afterRecv = std::chrono::steady_clock::now();
+
+        dns::debug::log(
+            "Client::sendMessage",
+            "recvfrom() returned " + std::to_string(received) +
+                " bytes after " +
+                dns::debug::formatDuration(afterRecv - afterSend));
+
         Response response;
         response.decode(buffer, received);
 
         std::string rdata = response.getRdata();
+
+        std::string rdataPreview = rdata.substr(0, 60);
+        if(rdata.size() > rdataPreview.size())
+            rdataPreview += "...";
+        dns::debug::log(
+            "Client::sendMessage",
+            "Received RDATA length=" +
+                std::to_string(static_cast<unsigned long long>(rdata.size())) +
+                " preview='" + rdataPreview + "'");
+
         handleResponse(rdata);
 
+        auto afterHandle = std::chrono::steady_clock::now();
+        dns::debug::log(
+            "Client::sendMessage",
+            "Response handling completed in " +
+                dns::debug::formatDuration(afterHandle - afterRecv) +
+                "; fragments remaining=" +
+                std::to_string(static_cast<unsigned long long>(m_msgQueue.size())) +
+                ", awaiting more=" +
+                (m_moreMsgToGet ? std::string("true") : std::string("false")));
+
+        dns::debug::log("Client::sendMessage",
+                        "Applying inter-query delay of 1000 ms to avoid flooding");
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+        dns::debug::log(
+            "Client::sendMessage",
+            "Iteration " + std::to_string(iteration) + " total time " +
+                dns::debug::formatDuration(std::chrono::steady_clock::now() -
+                                           iterationStart));
     }
+
+    dns::debug::log(
+        "Client::sendMessage",
+        "Transmission loop completed after " +
+            dns::debug::formatDuration(std::chrono::steady_clock::now() -
+                                       sessionStart) +
+            "; remaining fragments=" +
+            std::to_string(static_cast<unsigned long long>(m_msgQueue.size())) +
+            ", awaiting more=" +
+            (m_moreMsgToGet ? std::string("true") : std::string("false")));
 
 #ifdef __linux__
     close(sockfd);
@@ -137,4 +271,6 @@ void Client::sendMessage(const std::string& msg)
     closesocket(sockfd);
     WSACleanup();
 #endif
+
+    dns::debug::log("Client::sendMessage", "Socket closed");
 }

--- a/src/debugLog.hpp
+++ b/src/debugLog.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace dns
+{
+namespace debug
+{
+inline std::string timestamp()
+{
+    using namespace std::chrono;
+    const auto now = system_clock::now();
+    const auto timeT = system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &timeT);
+#else
+    localtime_r(&timeT, &tm);
+#endif
+    const auto duration = now.time_since_epoch();
+    const auto secondsPart = duration_cast<seconds>(duration);
+    const auto microsPart = duration_cast<microseconds>(duration - secondsPart);
+
+    std::ostringstream oss;
+    oss << std::put_time(&tm, "%Y-%m-%d %H:%M:%S")
+        << '.' << std::setw(6) << std::setfill('0') << microsPart.count();
+    return oss.str();
+}
+
+inline std::string formatDuration(std::chrono::steady_clock::duration duration)
+{
+    using namespace std::chrono;
+    const auto totalMicros = duration_cast<microseconds>(duration).count();
+
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(3)
+        << static_cast<double>(totalMicros) / 1000.0 << " ms ("
+        << totalMicros << " us)";
+    return oss.str();
+}
+
+inline void log(const std::string& component, const std::string& message)
+{
+    std::cout << '[' << timestamp() << "] [" << component << "] " << message << std::endl;
+}
+
+inline void logDuration(const std::string& component,
+                        const std::string& activity,
+                        std::chrono::steady_clock::duration duration)
+{
+    log(component, activity + " took " + formatDuration(duration));
+}
+} // namespace debug
+} // namespace dns
+

--- a/src/debugLog.hpp
+++ b/src/debugLog.hpp
@@ -11,6 +11,10 @@ namespace dns
 {
 namespace debug
 {
+#if defined(DNS_ENABLE_LOGGING)
+
+inline constexpr bool kEnabled = true;
+
 inline std::string timestamp()
 {
     using namespace std::chrono;
@@ -55,6 +59,38 @@ inline void logDuration(const std::string& component,
 {
     log(component, activity + " took " + formatDuration(duration));
 }
+
+#else
+
+inline constexpr bool kEnabled = false;
+
+inline std::string timestamp()
+{
+    return {};
+}
+
+inline std::string formatDuration(std::chrono::steady_clock::duration duration)
+{
+    (void)duration;
+    return {};
+}
+
+inline void log(const std::string& component, const std::string& message)
+{
+    (void)component;
+    (void)message;
+}
+
+inline void logDuration(const std::string& component,
+                        const std::string& activity,
+                        std::chrono::steady_clock::duration duration)
+{
+    (void)component;
+    (void)activity;
+    (void)duration;
+}
+
+#endif
 } // namespace debug
 } // namespace dns
 

--- a/src/dns.cpp
+++ b/src/dns.cpp
@@ -8,6 +8,7 @@
 
 #include "nlohmann/json.hpp"
 #include "dns.hpp"
+#include "debugLog.hpp"
 
 
 using namespace std;
@@ -18,11 +19,14 @@ using json = nlohmann::json;
 
 Dns::Dns(const std::string& domain)
 : m_domainToResolve(domain)
-{ 
+{
     m_maxMessageSize = getMaxMsgLen(domain);
     m_moreMsgToGet = false;
 
-    // std::cout << "maxMessageSize " << std::to_string(m_maxMessageSize) << std::endl;
+    dns::debug::log("Dns",
+                    "Initialized for domain '" + m_domainToResolve +
+                        "' with max payload size " +
+                        std::to_string(m_maxMessageSize) + " bytes");
 }
 
 
@@ -35,11 +39,18 @@ void Dns::setMsg(const std::string& msg)
 {
     const std::lock_guard<std::mutex> lock(m_mutex);
 
+    dns::debug::log("Dns::setMsg",
+                    "Preparing message of " + std::to_string(msg.size()) +
+                        " bytes for domain '" + m_domainToResolve + "'");
+
     std::string sessionId;
     do
     {
         sessionId = generateRandomString(5);
     } while (m_msgReceived.find(sessionId) != m_msgReceived.end());
+
+    dns::debug::log("Dns::setMsg",
+                    "Generated session identifier '" + sessionId + "'");
 
     json packetJson;
     packetJson["m"] = msg;
@@ -59,6 +70,13 @@ void Dns::setMsg(const std::string& msg)
         int maxLength = m_maxMessageSize - static_cast<int>(packet.size());
         size_t totalLen = msg.length();
         size_t startPos = 0;
+
+        dns::debug::log("Dns::setMsg",
+                        "Message exceeds max payload size (" +
+                            std::to_string(packet.size()) + " > " +
+                            std::to_string(m_maxMessageSize) +
+                            "), fragmenting with chunk capacity " +
+                            std::to_string(maxLength) + " bytes");
         while (startPos < totalLen)
         {
             size_t chunkSize = std::min<size_t>(maxLength, totalLen - startPos);
@@ -69,18 +87,41 @@ void Dns::setMsg(const std::string& msg)
         }
 
         size_t nbMaxMessage = messages.size();
+        dns::debug::log("Dns::setMsg",
+                        "Enqueued " + std::to_string(nbMaxMessage) +
+                            " fragment(s) for session '" + sessionId + "'");
         for(size_t i = 0; i < nbMaxMessage; ++i)
         {
+            const std::string chunkData = messages[i]["m"].get<std::string>();
             messages[i]["n"] = nbMaxMessage;
             messages[i]["k"] = i;
             std::string msgHex = stringToHex(messages[i].dump());
             m_msgQueue.push(msgHex);
+
+            dns::debug::log(
+                "Dns::setMsg",
+                "Fragment " + std::to_string(i + 1) + "/" +
+                    std::to_string(nbMaxMessage) + " for session '" +
+                    sessionId + "' raw=" + std::to_string(chunkData.size()) +
+                    " bytes encoded=" + std::to_string(msgHex.size()) +
+                    " hex chars; queue size=" +
+                    std::to_string(static_cast<unsigned long long>(
+                        m_msgQueue.size())));
         }
     }
     else
     {
         std::string msgHex = stringToHex(packet);
         m_msgQueue.push(msgHex);
+
+        dns::debug::log(
+            "Dns::setMsg",
+            "Message fits in a single fragment for session '" + sessionId +
+                "' raw=" + std::to_string(msg.size()) + " bytes encoded=" +
+                std::to_string(msgHex.size()) +
+                " hex chars; queue size=" +
+                std::to_string(static_cast<unsigned long long>(
+                    m_msgQueue.size())));
     }
 }
 
@@ -88,6 +129,12 @@ void Dns::addReceivedQName(const std::string& qname)
 {
     const std::lock_guard<std::mutex> lock(m_mutex);
     m_qnameReceived.push_back(qname);
+
+    dns::debug::log(
+        "Dns::addReceivedQName",
+        "Queued received QNAME '" + qname + "'; pending count=" +
+            std::to_string(
+                static_cast<unsigned long long>(m_qnameReceived.size())));
 }
 
 
@@ -99,7 +146,15 @@ void Dns::handleResponse(const std::string& rdata)
     // std::cout << "handleResponse:: rdata " << rdata << std::endl;
 
     if(startsWith(rdata, "admin"))
+    {
+        dns::debug::log("Dns::handleResponse",
+                        "Ignoring control record '" + rdata + "'");
         return;
+    }
+
+    dns::debug::log("Dns::handleResponse",
+                    "Processing RDATA of length " +
+                        std::to_string(rdata.size()));
 
     // Remove all the dots
     auto noDot = std::remove(msg.begin(), msg.end(), '.');
@@ -113,25 +168,35 @@ void Dns::handleResponse(const std::string& rdata)
     // std::cout << "handleResponse:: FUCKKKK " << msgReceived << std::endl;
 
     size_t lastBracePos = msgReceived.find_last_of('}');
-    if (lastBracePos == std::string::npos) 
+    if (lastBracePos == std::string::npos)
+    {
+        dns::debug::log("Dns::handleResponse",
+                        "Discarded response missing JSON terminator; raw='" +
+                            msgReceived + "'");
         return;
-    
+    }
+
     json packetJson;
-    try 
+    try
     {
         packetJson = json::parse(msgReceived.substr(0, lastBracePos+1));
-    } 
+    }
     catch (const std::exception& e)
     {
+        dns::debug::log(
+            "Dns::handleResponse",
+            std::string("Failed to parse JSON fragment: ") + e.what());
         return;
         // Catching all exceptions derived from std::exception
-    } 
-    catch (...) 
+    }
+    catch (...)
     {
+        dns::debug::log("Dns::handleResponse",
+                        "Failed to parse JSON fragment: unknown error");
         return;
         // Catching all other exceptions not derived from std::exception
     }
-    
+
     // std::cout << "handleResponse:: packetJson " << packetJson << std::endl;
 
     std::string session = packetJson["s"];
@@ -139,11 +204,22 @@ void Dns::handleResponse(const std::string& rdata)
     int k = packetJson["k"].get<int>();
     int n = packetJson["n"].get<int>();
 
+    const std::string payload = packetJson["m"].get<std::string>();
+
     auto& packet = m_msgReceived[session];
     if(packet.id.empty())
         packet.id = session;
-    packet.data.append(packetJson["m"].get<std::string>());
+    packet.data.append(payload);
     packet.isFull = (k == n-1);
+
+    dns::debug::log(
+        "Dns::handleResponse",
+        "Received fragment " + std::to_string(k + 1) + "/" +
+            std::to_string(n) + " for session '" + session + "' payload=" +
+            std::to_string(payload.size()) +
+            " bytes; accumulated=" +
+            std::to_string(static_cast<unsigned long long>(packet.data.size())) +
+            " bytes; isFull=" + (packet.isFull ? "true" : "false"));
 
     m_moreMsgToGet = false;
     for(const auto& p : m_msgReceived)
@@ -154,30 +230,45 @@ void Dns::handleResponse(const std::string& rdata)
             break;
         }
     }
+
+    dns::debug::log("Dns::handleResponse",
+                    std::string("More fragments pending: ") +
+                        (m_moreMsgToGet ? "yes" : "no"));
 }
 
 
 // return the first message that is available, or an empty string if no message is avalable
 std::string Dns::getMsg()
-{    
+{
     // only for server, for client handleResponse is executed on each process and qnameTmp is empty
-    std::unique_lock<std::mutex> lock(m_mutex);   
+    std::unique_lock<std::mutex> lock(m_mutex);
 
     std::vector<std::string> qnameTmp = m_qnameReceived;
     m_qnameReceived.clear();
 
     lock.unlock();
 
+    dns::debug::log(
+        "Dns::getMsg",
+        "Processing " +
+            std::to_string(static_cast<unsigned long long>(qnameTmp.size())) +
+            " queued QNAME(s)");
+
     for(int i=0; i<qnameTmp.size(); i++)
         handleResponse(qnameTmp[i]);
-    
+
     std::string result;
     for (auto it = m_msgReceived.begin(); it != m_msgReceived.end();)
     {
         if (it->second.isFull)
         {
+            std::string sessionId = it->first;
             result = it->second.data;
             it = m_msgReceived.erase(it);
+            dns::debug::log(
+                "Dns::getMsg",
+                "Completed session '" + sessionId +
+                    "' removed from pending map");
             break;
         }
         else
@@ -194,6 +285,27 @@ std::string Dns::getMsg()
             m_moreMsgToGet = true;
             break;
         }
+    }
+
+    if(!result.empty())
+    {
+        dns::debug::log(
+            "Dns::getMsg",
+            "Assembled complete message of " +
+                std::to_string(static_cast<unsigned long long>(result.size())) +
+                " bytes; remaining sessions=" +
+                std::to_string(
+                    static_cast<unsigned long long>(m_msgReceived.size())));
+    }
+    else
+    {
+        dns::debug::log(
+            "Dns::getMsg",
+            "No complete message available; pending sessions=" +
+                std::to_string(
+                    static_cast<unsigned long long>(m_msgReceived.size())) +
+                ", expecting more fragments=" +
+                (m_moreMsgToGet ? std::string("true") : std::string("false")));
     }
 
     return result;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -2,12 +2,14 @@
 #include <cstring>
 
 #include <algorithm>
+#include <chrono>
 #include <cctype>
 #include <string_view>
 
 #include <errno.h>
 
 #include "server.hpp"
+#include "debugLog.hpp"
 
 #ifdef _WIN32
 #pragma comment(lib, "ws2_32.lib")
@@ -17,15 +19,33 @@
 #include <unistd.h>
 #endif
 
+namespace
+{
+std::string endpointToString(const sockaddr_in& addr)
+{
+    char buffer[INET_ADDRSTRLEN] = {0};
+#ifdef _WIN32
+    if (InetNtopA(AF_INET, const_cast<in_addr*>(&addr.sin_addr), buffer, INET_ADDRSTRLEN) == nullptr)
+        return std::string("<invalid>");
+#else
+    if (inet_ntop(AF_INET, &(addr.sin_addr), buffer, sizeof(buffer)) == nullptr)
+        return std::string("<invalid>");
+#endif
+    return std::string(buffer) + ":" + std::to_string(ntohs(addr.sin_port));
+}
+}
+
 using namespace std;
 using namespace dns;
 
 
-Server::Server(int port, const std::string& domainToResolve) 
+Server::Server(int port, const std::string& domainToResolve)
 : Dns(domainToResolve)
 , m_port(port)
-{ 
-
+{
+    dns::debug::log("Server",
+                    "Constructed for domain '" + m_domainToResolve +
+                        "' on port " + std::to_string(m_port));
 }
 
 
@@ -38,21 +58,32 @@ Server::~Server()
 void Server::stop()
 {
     if (m_isStoped)
+    {
+        dns::debug::log("Server::stop",
+                        "Stop requested but server already stopped");
         return;
+    }
+    dns::debug::log("Server::stop",
+                    "Stopping server on port " + std::to_string(m_port));
     m_isStoped=true;
     // Send an empty datagram to unblock recvfrom
     struct sockaddr_in addr = m_address;
     addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     char byte = 0;
     sendto(m_sockfd, &byte, 1, 0, (struct sockaddr*)&addr, sizeof(addr));
+    dns::debug::log("Server::stop", "Sent loopback datagram to unblock recvfrom");
     if(m_dnsServ && m_dnsServ->joinable())
+    {
+        dns::debug::log("Server::stop", "Joining worker thread");
         m_dnsServ->join();
+    }
 #ifdef __linux__
     close(m_sockfd);
 #elif _WIN32
     closesocket(m_sockfd);
     WSACleanup();
 #endif
+    dns::debug::log("Server::stop", "Socket closed");
 }
 
 
@@ -60,25 +91,45 @@ void Server::launch()
 {
 #ifdef _WIN32
     WSADATA wsa{};
-    if (WSAStartup(MAKEWORD(2,2), &wsa) != 0) 
+    if (WSAStartup(MAKEWORD(2,2), &wsa) != 0)
     {
         std::cerr << "[dns::Server] WSAStartup failed\n";
         return;
     }
 #endif
 
+    dns::debug::log("Server::launch",
+                    "Launching server for domain '" + m_domainToResolve +
+                        "' on port " + std::to_string(m_port));
+
     m_isStoped=false;
     m_sockfd = socket(AF_INET, SOCK_DGRAM, 0);
+
+    if(m_sockfd < 0)
+    {
+        dns::debug::log("Server::launch",
+                        "socket() failed: " + std::string(strerror(errno)));
+        m_isStoped = true;
+#ifdef _WIN32
+        WSACleanup();
+#endif
+        return;
+    }
+
+    dns::debug::log("Server::launch", "Socket created (fd=" +
+                                         std::to_string(m_sockfd) + ")");
 
     m_address.sin_family = AF_INET;
     m_address.sin_addr.s_addr = INADDR_ANY;
     m_address.sin_port = htons(m_port);
 
     int rbind = bind(m_sockfd, (struct sockaddr *) & m_address, sizeof(struct sockaddr_in));
-    if (rbind != 0) 
+    if (rbind != 0)
     {
         string text("Could not bind: ");
         text += strerror(errno);
+
+        dns::debug::log("Server::launch", text);
 
 #ifdef _WIN32
         WSACleanup();
@@ -87,40 +138,111 @@ void Server::launch()
         return;
     }
 
+    dns::debug::log("Server::launch",
+                    "Socket bound to port " + std::to_string(m_port));
+
     this->m_dnsServ = std::make_unique<std::thread>(&Server::run, this);
+    dns::debug::log("Server::launch", "Worker thread started");
 }
 
 
 void Server::run()
-{    
+{
     char buffer[BUFFER_SIZE];
     struct sockaddr_in clientAddress;
     socklen_t addrLen = sizeof (struct sockaddr_in);
 
-    while(!m_isStoped) 
+    dns::debug::log("Server::run", "Worker loop started");
+
+    while(!m_isStoped)
     {
+        auto waitStart = std::chrono::steady_clock::now();
         int nbytes = recvfrom(m_sockfd, buffer, BUFFER_SIZE, 0, (struct sockaddr *) &clientAddress, &addrLen);
+        auto afterRecv = std::chrono::steady_clock::now();
+
+        if(nbytes <= 0)
+        {
+            if(m_isStoped)
+            {
+                dns::debug::log("Server::run",
+                                "recvfrom() returned " + std::to_string(nbytes) +
+                                    " while stopping");
+                break;
+            }
+
+            dns::debug::log("Server::run",
+                            "recvfrom() returned " + std::to_string(nbytes) +
+                                ", continuing");
+            continue;
+        }
+
+        std::string clientEndpoint = endpointToString(clientAddress);
+        dns::debug::log(
+            "Server::run",
+            "Received " + std::to_string(nbytes) + " bytes from " +
+                clientEndpoint + " after " +
+                dns::debug::formatDuration(afterRecv - waitStart));
 
         Query query;
         query.decode(buffer, nbytes);
 
         std::string qname = query.getQName();
+
+        dns::debug::log(
+            "Server::run",
+            "Decoded query id=" + std::to_string(query.getID()) + " qname='" +
+                qname + "' qtype=" + std::to_string(query.getQType()) +
+                " qclass=" + std::to_string(query.getQClass()));
+
         addReceivedQName(qname);
 
         Response response;
+        auto handleStart = std::chrono::steady_clock::now();
         handleQuery(query, response);
+        auto afterHandle = std::chrono::steady_clock::now();
+
+        dns::debug::log(
+            "Server::run",
+            "handleQuery completed in " +
+                dns::debug::formatDuration(afterHandle - handleStart) +
+                "; outbound fragment queue size=" +
+                std::to_string(
+                    static_cast<unsigned long long>(m_msgQueue.size())));
 
         memset(buffer, 0, BUFFER_SIZE);
         nbytes = response.code(buffer);
 
-        sendto(m_sockfd, buffer, nbytes, 0, (struct sockaddr *) &clientAddress, addrLen);
+        dns::debug::log(
+            "Server::run",
+            "Encoded response of " + std::to_string(nbytes) +
+                " bytes with RDATA length=" +
+                std::to_string(
+                    static_cast<unsigned long long>(response.getRdata().size())));
+
+        auto beforeSend = std::chrono::steady_clock::now();
+        int sent = sendto(m_sockfd, buffer, nbytes, 0, (struct sockaddr *) &clientAddress, addrLen);
+        auto afterSend = std::chrono::steady_clock::now();
+
+        dns::debug::log(
+            "Server::run",
+            "Sent " + std::to_string(sent) + " bytes to " + clientEndpoint +
+                " in " +
+                dns::debug::formatDuration(afterSend - beforeSend));
     }
+
+    dns::debug::log("Server::run", "Worker loop terminated");
 }
 
 
 void Server::handleQuery(const Query& query, Response& response)
 {
     string qName = query.getQName();
+
+    dns::debug::log(
+        "Server::handleQuery",
+        "Processing query name '" + qName + "'; pending outbound fragments=" +
+            std::to_string(
+                static_cast<unsigned long long>(m_msgQueue.size())));
 
     string domainName = "";
     if (endsWith(qName, m_domainToResolve))
@@ -129,19 +251,35 @@ void Server::handleQuery(const Query& query, Response& response)
         {
             domainName = m_msgQueue.front();
             m_msgQueue.pop();
+
+            dns::debug::log(
+                "Server::handleQuery",
+                "Using queued fragment for response; remaining fragments=" +
+                    std::to_string(static_cast<unsigned long long>(
+                        m_msgQueue.size())) +
+                    " payload='" + domainName + "'");
         }
         else
         {
             domainName = "admin";
             domainName += generateRandomString(8);
+
+            dns::debug::log(
+                "Server::handleQuery",
+                "No payload available; sending control domain '" + domainName +
+                    "'");
         }
     }
 
     // std::cout << "domainName " << domainName << std::endl;
-    
-    if (domainName.empty()) 
+
+    if (domainName.empty())
     {
         // cout << "[-] Domain not in scope !" << endl;
+
+        dns::debug::log(
+            "Server::handleQuery",
+            "Domain '" + qName + "' not in scope; sending NameError");
 
         response.setID( query.getID() );
         response.setName( query.getQName() );
@@ -150,9 +288,15 @@ void Server::handleQuery(const Query& query, Response& response)
         response.setRCode(Response::NameError);
         response.setRdLength(1); // null label
     }
-    else 
+    else
     {
         // cout << "[+] Domain in scope !" << endl;
+
+        dns::debug::log(
+            "Server::handleQuery",
+            "Responding with payload '" + domainName + "' (" +
+                std::to_string(static_cast<unsigned long long>(domainName.size())) +
+                " bytes)");
 
         response.setRCode(Response::Ok);
         response.setRdLength(domainName.size()+2); // + initial label length & null label


### PR DESCRIPTION
## Summary
- add a shared logging helper that timestamps messages and formats durations
- expand dns core logging to trace fragmentation, response assembly, and message retrieval
- instrument client and server flows with detailed communication metrics, payload previews, and timing information

## Testing
- `cmake ..`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68cd7b7f7abc83258e6f418ff8168208