### PR TITLE
Add typed DNS RDATA handling with variant storage

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,4 +1,4 @@
-#include <iostream>
+#include <array>
 #include <algorithm>
 #include <cctype>
 #include <string_view>
@@ -13,8 +13,108 @@
 
 #include "client.hpp"
 
+#ifdef __linux__
+#include <arpa/inet.h>
+#endif
+
 using namespace std;
 using namespace dns;
+
+namespace
+{
+
+bool looksLikeIPv4(const std::string& text)
+{
+    if (std::count(text.begin(), text.end(), '.') != 3)
+        return false;
+
+    size_t start = 0;
+    for (int i = 0; i < 4; ++i)
+    {
+        size_t end = text.find('.', start);
+        if (end == std::string::npos)
+            end = text.size();
+
+        if (end <= start || end - start > 3)
+            return false;
+
+        int value = 0;
+        for (size_t j = start; j < end; ++j)
+        {
+            unsigned char c = static_cast<unsigned char>(text[j]);
+            if (!std::isdigit(c))
+                return false;
+            value = value * 10 + (c - '0');
+            if (value > 255)
+                return false;
+        }
+
+        start = end + 1;
+    }
+
+    return start == text.size() + 1;
+}
+
+
+bool looksLikeIPv6(const std::string& text)
+{
+    if (text.find(':') == std::string::npos)
+        return false;
+
+    std::array<uint8_t, 16> buffer{};
+    int res = inet_pton(AF_INET6, text.c_str(), buffer.data());
+    return res == 1;
+}
+
+
+bool looksLikeDomain(const std::string& text)
+{
+    if (text.empty())
+        return false;
+    if (text.size() > 253)
+        return false;
+    if (text.find('.') == std::string::npos)
+        return false;
+    if (text.find("..") != std::string::npos)
+        return false;
+
+    size_t start = 0;
+    while (start < text.size())
+    {
+        size_t dot = text.find('.', start);
+        size_t length = (dot == std::string::npos) ? text.size() - start : dot - start;
+        if (length == 0 || length > 63)
+            return false;
+
+        for (size_t i = 0; i < length; ++i)
+        {
+            unsigned char c = static_cast<unsigned char>(text[start + i]);
+            if (!(std::isalnum(c) || c == '-'))
+                return false;
+        }
+
+        if (dot == std::string::npos)
+            break;
+        start = dot + 1;
+    }
+
+    return true;
+}
+
+
+uint16_t inferQueryType(const std::string& payload)
+{
+    if (looksLikeIPv4(payload))
+        return 1;
+    if (looksLikeIPv6(payload))
+        return 28;
+    if (looksLikeDomain(payload))
+        return 5;
+    return 16;
+}
+
+}
+
 
 Client::Client(const std::string& dnsServerAdd, const std::string& domainToResolve, int port)
 : Dns(domainToResolve)
@@ -67,11 +167,14 @@ void Client::sendMessage(const std::string& msg)
     while(!m_msgQueue.empty() || m_moreMsgToGet)
     {
         std::string qname;
+        uint16_t qtype = 16;
+
         if(!m_msgQueue.empty())
         {
             std::string subdomain = addDotEvery62Chars(m_msgQueue.front());
             qname += subdomain;
             qname += ".";
+            qtype = inferQueryType(m_msgQueue.front());
             m_msgQueue.pop();
         }
         else
@@ -83,7 +186,7 @@ void Client::sendMessage(const std::string& msg)
 
         qname += m_domainToResolve;
         query.setQName(qname);
-        query.setQType(16);
+        query.setQType(qtype);
         query.setQClass(1);
 
         nbytes = query.code(buffer);
@@ -125,7 +228,7 @@ void Client::sendMessage(const std::string& msg)
         Response response;
         response.decode(buffer, received);
 
-        std::string rdata = response.getRdata();
+        std::string rdata = response.getRdataAsString();
         handleResponse(rdata);
 
         // TODO make it configurable - Resolvers usually accept ~5–20 qps per client without rate-limiting. Above that, some will throttle or blacklist.

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -146,7 +146,7 @@ int Message::get32bits(const char*& buffer)
 }
 
 
-void Message::put16bits(char*& buffer, uint value)  
+void Message::put16bits(char*& buffer, uint value) const
 {
     buffer[0] = (value & 0xFF00) >> 8;
     buffer[1] = value & 0xFF;
@@ -154,7 +154,7 @@ void Message::put16bits(char*& buffer, uint value)
 }
 
 
-void Message::put32bits(char*& buffer, ulong value)  
+void Message::put32bits(char*& buffer, ulong value) const
 {
     buffer[0] = (value >> 24) & 0xFF;
     buffer[1] = (value >> 16) & 0xFF;

--- a/src/message.hpp
+++ b/src/message.hpp
@@ -89,8 +89,8 @@ protected:
     int get16bits(const char*& buffer) ;
     int get32bits(const char*& buffer) ;
 
-    void put16bits(char*& buffer, uint value) ;
-    void put32bits(char*& buffer, ulong value) ;
+    void put16bits(char*& buffer, uint value) const;
+    void put32bits(char*& buffer, ulong value) const;
 
     void log_buffer(const char* buffer, int size) ;
     

--- a/src/response.cpp
+++ b/src/response.cpp
@@ -1,7 +1,7 @@
-#include <iostream>
+#include <algorithm>
+#include <iomanip>
 #include <sstream>
-#include <cstdint>
-#include <cstring>
+#include <utility>
 #include <set>
 
 #ifdef __linux__
@@ -19,28 +19,193 @@
 #include "message.hpp"
 #include "response.hpp"
 
+namespace {
+
+template <typename... Ts>
+struct Overloaded : Ts...
+{
+    using Ts::operator()...;
+};
+
+template <typename... Ts>
+Overloaded(Ts...) -> Overloaded<Ts...>;
+
+}
+
 using namespace std;
 using namespace dns;
 
 
-Response::Response() 
-: Message(Message::Response) 
-{ 
+Response::Response()
+: Message(Message::Response)
+{
     m_name="";
     m_type=0;
     m_class=0;
     m_ttl=0;
     m_rdLength=0;
-    m_rdata="";
+    m_rdata = std::monostate{};
 }
 
 
-Response::~Response() 
-{ 
+Response::~Response() = default;
+
+
+void Response::clearRdata()
+{
+    m_rdata = std::monostate{};
+    m_rdLength = 0;
 }
 
 
-string Response::asString() const 
+void Response::setTxtRdata(const std::string& value)
+{
+    TxtRdata data;
+    if (value.empty())
+    {
+        data.texts.emplace_back("");
+    }
+    else
+    {
+        size_t pos = 0;
+        while (pos < value.size())
+        {
+            size_t len = std::min<size_t>(255, value.size() - pos);
+            data.texts.emplace_back(value.substr(pos, len));
+            pos += len;
+        }
+    }
+
+    setTxtRdata(data);
+}
+
+
+void Response::setTxtRdata(const TxtRdata& value)
+{
+    TxtRdata normalized;
+    if (value.texts.empty())
+    {
+        normalized.texts.emplace_back("");
+    }
+    else
+    {
+        for (const auto& chunk : value.texts)
+        {
+            if (chunk.empty())
+            {
+                normalized.texts.emplace_back("");
+                continue;
+            }
+
+            size_t pos = 0;
+            while (pos < chunk.size())
+            {
+                size_t len = std::min<size_t>(255, chunk.size() - pos);
+                normalized.texts.emplace_back(chunk.substr(pos, len));
+                pos += len;
+            }
+        }
+    }
+
+    m_rdata = std::move(normalized);
+    m_rdLength = computeRdataLength();
+}
+
+
+void Response::setAddressRdata(const std::vector<uint8_t>& value)
+{
+    setAddressRdata(AddressRdata{value});
+}
+
+
+void Response::setAddressRdata(const AddressRdata& value)
+{
+    m_rdata = value;
+    m_rdLength = computeRdataLength();
+}
+
+
+void Response::setDomainRdata(const std::string& value)
+{
+    setDomainRdata(DomainRdata{value, std::nullopt});
+}
+
+
+void Response::setDomainRdata(const DomainRdata& value)
+{
+    m_rdata = value;
+    m_rdLength = computeRdataLength();
+}
+
+
+void Response::setRawRdata(const std::vector<uint8_t>& value)
+{
+    setRawRdata(RawRdata{value});
+}
+
+
+void Response::setRawRdata(const RawRdata& value)
+{
+    m_rdata = value;
+    m_rdLength = computeRdataLength();
+}
+
+
+string Response::getRdataAsString() const
+{
+    return std::visit(Overloaded{
+        [](const std::monostate&) -> string { return {}; },
+        [](const TxtRdata& data) -> string {
+            string result;
+            for (size_t i = 0; i < data.texts.size(); ++i)
+            {
+                if (i != 0)
+                    result.push_back(' ');
+                result += data.texts[i];
+            }
+            return result;
+        },
+        [](const AddressRdata& data) -> string {
+            if (data.bytes.empty())
+                return {};
+
+            if (data.bytes.size() == 4)
+            {
+                ostringstream oss;
+                oss << static_cast<int>(data.bytes[0]) << '.'
+                    << static_cast<int>(data.bytes[1]) << '.'
+                    << static_cast<int>(data.bytes[2]) << '.'
+                    << static_cast<int>(data.bytes[3]);
+                return oss.str();
+            }
+
+            ostringstream oss;
+            oss << std::hex << std::setfill('0');
+            for (size_t i = 0; i < data.bytes.size(); ++i)
+            {
+                if (i != 0 && i % 2 == 0)
+                    oss << ':';
+                oss << std::setw(2) << static_cast<int>(data.bytes[i]);
+            }
+            return oss.str();
+        },
+        [](const DomainRdata& data) -> string {
+            if (data.preference.has_value())
+            {
+                ostringstream oss;
+                oss << data.preference.value() << ' ' << data.name;
+                return oss.str();
+            }
+            return data.name;
+        },
+        [](const RawRdata& data) -> string {
+            return string(data.bytes.begin(), data.bytes.end());
+        }
+    }, m_rdata);
+}
+
+
+string Response::asString() const
 {
     ostringstream text;
     text << endl << "RESPONSE { ";
@@ -51,7 +216,7 @@ string Response::asString() const
     text << "\tclass: " << m_class << endl;
     text << "\tttl: " << m_ttl << endl;
     text << "\trdLength: " << m_rdLength << endl;
-    text << "\trdata: " << m_rdata << " }" << dec;
+    text << "\trdata: " << getRdataAsString() << " }" << dec;
 
     return text.str();
 }
@@ -62,61 +227,95 @@ void Response::decode(const char* buffer, int size)
     const char* begin = buffer;
     const char* end = buffer + size;
 
+    clearRdata();
+
     decode_hdr(buffer);
     buffer += HDR_OFFSET;
 
-    // query
-    std::string respDom;
-    decode_domain(buffer, respDom, begin, end);
-    m_name = respDom;
+    if (m_qdCount > 0)
+    {
+        std::string questionName;
+        decode_domain(buffer, questionName, begin, end);
+        m_name = questionName;
+        m_type = get16bits(buffer);
+        m_class = get16bits(buffer);
+    }
+
+    if (m_anCount == 0)
+    {
+        return;
+    }
+
+    std::string answerName;
+    decode_domain(buffer, answerName, begin, end);
+    m_name = answerName;
     m_type = get16bits(buffer);
     m_class = get16bits(buffer);
-
-    // answer
-    decode_domain(buffer, respDom, begin, end);
-    m_name = respDom;
-    uint type_ = get16bits(buffer);
-    uint class_ = get16bits(buffer);
     m_ttl = get32bits(buffer);
+    m_rdLength = get16bits(buffer);
 
-    if(type_ == 16)
+    if (buffer + m_rdLength > end)
     {
-        m_rdLength = get16bits(buffer);
-        // skip la size ?
-        buffer++;
-        for (int i = 0; i < m_rdLength; i++) 
-        {
-            char c = *buffer++;
-            m_rdata.append(1, c);
-        }
+        buffer = end;
+        clearRdata();
+        return;
     }
-    else
+
+    switch (m_type)
     {
-        // std::cout << "TODO: decode type diff than txt" << std::endl;
+        case 1:
+        case 28:
+            m_rdata = decodeAddressRdata(buffer, static_cast<uint16_t>(m_rdLength));
+            break;
+        case 5:
+            m_rdata = decodeDomainRdata(buffer, begin, end, false);
+            break;
+        case 15:
+        {
+            if (m_rdLength < 2)
+            {
+                m_rdata = decodeRawRdata(buffer, static_cast<uint16_t>(m_rdLength));
+                break;
+            }
+            DomainRdata domain = decodeDomainRdata(buffer, begin, end, true);
+            m_rdata = std::move(domain);
+            break;
+        }
+        case 16:
+            m_rdata = decodeTxtRdata(buffer, static_cast<uint16_t>(m_rdLength));
+            break;
+        default:
+            m_rdata = decodeRawRdata(buffer, static_cast<uint16_t>(m_rdLength));
+            break;
     }
 }
 
 
-int Response::code(char* buffer) 
+int Response::code(char* buffer)
 {
     char* bufferBegin = buffer;
 
     code_hdr(buffer);
     buffer += HDR_OFFSET;
 
-    // Code Question section
-    code_domain(buffer, m_name);
-    put16bits(buffer, m_type);
-    put16bits(buffer, m_class);
+    if (m_qdCount > 0)
+    {
+        code_domain(buffer, m_name);
+        put16bits(buffer, m_type);
+        put16bits(buffer, m_class);
+    }
 
-    // Code Answer section
-    put16bits(buffer, 49164);
-    // code_domain(buffer, m_name);
-    put16bits(buffer, m_type);
-    put16bits(buffer, m_class);
-    put32bits(buffer, m_ttl);
-    put16bits(buffer, m_rdLength);
-    code_domain(buffer, m_rdata);
+    if (m_anCount > 0)
+    {
+        put16bits(buffer, 0xC00C);
+        put16bits(buffer, m_type);
+        put16bits(buffer, m_class);
+        put32bits(buffer, m_ttl);
+
+        m_rdLength = computeRdataLength();
+        put16bits(buffer, m_rdLength);
+        encodeCurrentRdata(buffer);
+    }
 
     int size = buffer - bufferBegin;
     log_buffer(bufferBegin, size);
@@ -171,26 +370,171 @@ void Response::decode_domain(const char*& buffer, std::string& domain,
 }
 
 
-void Response::code_domain(char*& buffer, const std::string& domain) 
+void Response::code_domain(char*& buffer, const std::string& domain) const
 {
-    int start(0), end; // indexes
+    int start(0), end;
 
-    while ((end = domain.find('.', start)) != string::npos) 
+    while ((end = domain.find('.', start)) != string::npos)
     {
-
-        *buffer++ = end - start; // label length octet
+        *buffer++ = end - start;
         for (int i=start; i<end; i++) {
-
-            *buffer++ = domain[i]; // label octets
+            *buffer++ = domain[i];
         }
-        start = end + 1; // Skip '.'
+        start = end + 1;
     }
 
-    *buffer++ = domain.size() - start; // last label length octet
+    *buffer++ = domain.size() - start;
     for (int i=start; i<domain.size(); i++) {
-
-        *buffer++ = domain[i]; // last label octets
+        *buffer++ = domain[i];
     }
 
     *buffer++ = 0;
 }
+
+
+void Response::encodeAddressRdata(char*& buffer, const AddressRdata& data) const
+{
+    for (auto byte : data.bytes)
+    {
+        *buffer++ = static_cast<char>(byte);
+    }
+}
+
+
+void Response::encodeDomainRdata(char*& buffer, const DomainRdata& data) const
+{
+    if (data.preference.has_value())
+    {
+        put16bits(buffer, data.preference.value());
+    }
+
+    code_domain(buffer, data.name);
+}
+
+
+void Response::encodeTxtRdata(char*& buffer, const TxtRdata& data) const
+{
+    for (const auto& text : data.texts)
+    {
+        *buffer++ = static_cast<char>(text.size());
+        std::copy(text.begin(), text.end(), buffer);
+        buffer += text.size();
+    }
+}
+
+
+void Response::encodeRawRdata(char*& buffer, const RawRdata& data) const
+{
+    for (auto byte : data.bytes)
+    {
+        *buffer++ = static_cast<char>(byte);
+    }
+}
+
+
+Response::AddressRdata Response::decodeAddressRdata(const char*& buffer, uint16_t length)
+{
+    AddressRdata data;
+    data.bytes.reserve(length);
+    for (uint16_t i = 0; i < length; ++i)
+    {
+        data.bytes.push_back(static_cast<uint8_t>(*buffer++));
+    }
+    return data;
+}
+
+
+Response::DomainRdata Response::decodeDomainRdata(const char*& buffer, const char* begin,
+                                                  const char* end, bool hasPreference)
+{
+    DomainRdata data;
+    if (hasPreference)
+    {
+        data.preference = static_cast<uint16_t>(get16bits(buffer));
+    }
+    decode_domain(buffer, data.name, begin, end);
+    return data;
+}
+
+
+Response::TxtRdata Response::decodeTxtRdata(const char*& buffer, uint16_t length)
+{
+    TxtRdata data;
+    const char* end = buffer + length;
+
+    while (buffer < end)
+    {
+        uint8_t chunkLength = static_cast<uint8_t>(*buffer++);
+        if (buffer + chunkLength > end)
+        {
+            chunkLength = static_cast<uint8_t>(end - buffer);
+        }
+        data.texts.emplace_back(buffer, buffer + chunkLength);
+        buffer += chunkLength;
+    }
+
+    if (data.texts.empty())
+        data.texts.emplace_back("");
+
+    return data;
+}
+
+
+Response::RawRdata Response::decodeRawRdata(const char*& buffer, uint16_t length)
+{
+    RawRdata data;
+    data.bytes.reserve(length);
+    for (uint16_t i = 0; i < length; ++i)
+    {
+        data.bytes.push_back(static_cast<uint8_t>(*buffer++));
+    }
+    return data;
+}
+
+
+void Response::encodeCurrentRdata(char*& buffer) const
+{
+    std::visit(Overloaded{
+        [](const std::monostate&) {},
+        [this, &buffer](const TxtRdata& data) { encodeTxtRdata(buffer, data); },
+        [this, &buffer](const AddressRdata& data) { encodeAddressRdata(buffer, data); },
+        [this, &buffer](const DomainRdata& data) { encodeDomainRdata(buffer, data); },
+        [this, &buffer](const RawRdata& data) { encodeRawRdata(buffer, data); }
+    }, m_rdata);
+}
+
+
+uint Response::computeRdataLength() const
+{
+    return std::visit(Overloaded{
+        [](const std::monostate&) -> uint { return 0; },
+        [](const TxtRdata& data) -> uint {
+            uint total = 0;
+            for (const auto& text : data.texts)
+                total += static_cast<uint>(1 + text.size());
+            return total;
+        },
+        [](const AddressRdata& data) -> uint {
+            return static_cast<uint>(data.bytes.size());
+        },
+        [this](const DomainRdata& data) -> uint {
+            uint length = computeDomainEncodedLength(data.name);
+            if (data.preference.has_value())
+                length += 2;
+            return length;
+        },
+        [](const RawRdata& data) -> uint {
+            return static_cast<uint>(data.bytes.size());
+        }
+    }, m_rdata);
+}
+
+
+uint Response::computeDomainEncodedLength(const std::string& domain) const
+{
+    if (domain.empty())
+        return 1;
+
+    return static_cast<uint>(domain.size() + 2);
+}
+

--- a/src/response.hpp
+++ b/src/response.hpp
@@ -2,23 +2,37 @@
 
 #include "message.hpp"
 
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <vector>
 
-namespace dns 
+
+namespace dns
 {
 
-class Response : public Message 
+class Response : public Message
 {
 public:
 
     enum Code { Ok=0, FormatError, ServerFailure, NameError, NotImplemented, Refused };
 
+    struct TxtRdata { std::vector<std::string> texts; };
+    struct AddressRdata { std::vector<uint8_t> bytes; };
+    struct DomainRdata {
+        std::string name;
+        std::optional<uint16_t> preference;
+    };
+    struct RawRdata { std::vector<uint8_t> bytes; };
+    using RdataVariant = std::variant<std::monostate, TxtRdata, AddressRdata, DomainRdata, RawRdata>;
+
     Response();
     ~Response();
 
-    int code(char* buffer);
-    void decode(const char* buffer, int size);
+    int code(char* buffer) override;
+    void decode(const char* buffer, int size) override;
 
-    std::string asString() const;
+    std::string asString() const override;
 
     void setRCode(Code code) { m_rcode = code; }
     void setName(const std::string& value) { m_name = value; }
@@ -26,21 +40,45 @@ public:
     void setClass(const uint value) { m_class = value; }
     void setTtl(const ulong value) { m_ttl = value; }
     void setRdLength(const uint value) { m_rdLength = value; }
-    void setRdata(const std::string& value) { m_rdata = value; }
 
-    const std::string& getRdata() { return m_rdata; }
+    void clearRdata();
+    void setTxtRdata(const std::string& value);
+    void setTxtRdata(const TxtRdata& value);
+    void setAddressRdata(const std::vector<uint8_t>& value);
+    void setAddressRdata(const AddressRdata& value);
+    void setDomainRdata(const std::string& value);
+    void setDomainRdata(const DomainRdata& value);
+    void setRawRdata(const std::vector<uint8_t>& value);
+    void setRawRdata(const RawRdata& value);
+
+    const RdataVariant& getRdata() const { return m_rdata; }
+    std::string getRdataAsString() const;
     const std::string& getName() const { return m_name; }
-    
+
 private:
     std::string m_name;
     uint m_type;
     uint m_class;
     ulong m_ttl;
     uint m_rdLength;
-    std::string m_rdata;
+    RdataVariant m_rdata;
 
     void decode_domain(const char*& buffer, std::string& domain, const char* begin, const char* end);
-    void code_domain(char*& buffer, const std::string& domain);
+    void code_domain(char*& buffer, const std::string& domain) const;
+
+    void encodeAddressRdata(char*& buffer, const AddressRdata& data) const;
+    void encodeDomainRdata(char*& buffer, const DomainRdata& data) const;
+    void encodeTxtRdata(char*& buffer, const TxtRdata& data) const;
+    void encodeRawRdata(char*& buffer, const RawRdata& data) const;
+
+    AddressRdata decodeAddressRdata(const char*& buffer, uint16_t length);
+    DomainRdata decodeDomainRdata(const char*& buffer, const char* begin, const char* end, bool hasPreference);
+    TxtRdata decodeTxtRdata(const char*& buffer, uint16_t length);
+    RawRdata decodeRawRdata(const char*& buffer, uint16_t length);
+
+    void encodeCurrentRdata(char*& buffer) const;
+    uint computeRdataLength() const;
+    uint computeDomainEncodedLength(const std::string& domain) const;
 };
 
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,5 +1,7 @@
-#include <iostream>
+#include <array>
 #include <cstring>
+#include <optional>
+#include <vector>
 
 #include <algorithm>
 #include <cctype>
@@ -20,8 +22,118 @@
 using namespace std;
 using namespace dns;
 
+namespace
+{
 
-Server::Server(int port, const std::string& domainToResolve) 
+bool parseIPv4Address(const std::string& text, std::vector<uint8_t>& out)
+{
+    out.clear();
+    if (std::count(text.begin(), text.end(), '.') != 3)
+        return false;
+
+    size_t start = 0;
+    for (int i = 0; i < 4; ++i)
+    {
+        size_t end = text.find('.', start);
+        if (end == std::string::npos)
+            end = text.size();
+
+        if (end <= start || end - start > 3)
+            return false;
+
+        int value = 0;
+        for (size_t j = start; j < end; ++j)
+        {
+            unsigned char c = static_cast<unsigned char>(text[j]);
+            if (!std::isdigit(c))
+                return false;
+            value = value * 10 + (c - '0');
+            if (value > 255)
+                return false;
+        }
+
+        out.push_back(static_cast<uint8_t>(value));
+        start = end + 1;
+    }
+
+    return out.size() == 4 && start == text.size() + 1;
+}
+
+
+bool parseIPv6Address(const std::string& text, std::vector<uint8_t>& out)
+{
+    out.clear();
+    if (text.find(':') == std::string::npos)
+        return false;
+
+    std::array<uint8_t, 16> buffer{};
+    int res = inet_pton(AF_INET6, text.c_str(), buffer.data());
+    if (res != 1)
+        return false;
+
+    out.assign(buffer.begin(), buffer.end());
+    return true;
+}
+
+
+bool looksLikeDomainName(const std::string& text)
+{
+    if (text.empty())
+        return false;
+    if (text.size() > 253)
+        return false;
+    if (text.find('.') == std::string::npos)
+        return false;
+    if (text.find("..") != std::string::npos)
+        return false;
+
+    size_t start = 0;
+    while (start < text.size())
+    {
+        size_t dot = text.find('.', start);
+        size_t length = (dot == std::string::npos) ? text.size() - start : dot - start;
+        if (length == 0 || length > 63)
+            return false;
+
+        for (size_t i = 0; i < length; ++i)
+        {
+            unsigned char c = static_cast<unsigned char>(text[start + i]);
+            if (!(std::isalnum(c) || c == '-'))
+                return false;
+        }
+
+        if (dot == std::string::npos)
+            break;
+        start = dot + 1;
+    }
+
+    return true;
+}
+
+
+std::optional<uint16_t> parsePreference(const std::string& text)
+{
+    if (text.empty())
+        return std::nullopt;
+
+    unsigned long value = 0;
+    for (char c : text)
+    {
+        unsigned char uc = static_cast<unsigned char>(c);
+        if (!std::isdigit(uc))
+            return std::nullopt;
+        value = value * 10 + (uc - '0');
+        if (value > 65535)
+            return std::nullopt;
+    }
+
+    return static_cast<uint16_t>(value);
+}
+
+}
+
+
+Server::Server(int port, const std::string& domainToResolve)
 : Dns(domainToResolve)
 , m_port(port)
 { 
@@ -139,34 +251,93 @@ void Server::handleQuery(const Query& query, Response& response)
 
     // std::cout << "domainName " << domainName << std::endl;
     
-    if (domainName.empty()) 
-    {
-        // cout << "[-] Domain not in scope !" << endl;
+    response.setID(query.getID());
+    response.setName(query.getQName());
+    response.setClass(query.getQClass());
+    response.setType(query.getQType());
+    response.setQdCount(1);
+    response.setAnCount(0);
+    response.setNsCount(0);
+    response.setArCount(0);
+    response.clearRdata();
 
-        response.setID( query.getID() );
-        response.setName( query.getQName() );
-        response.setType( query.getQType() );
-        response.setClass( query.getQClass() );
+    if (domainName.empty())
+    {
         response.setRCode(Response::NameError);
-        response.setRdLength(1); // null label
+        return;
     }
-    else 
+
+    uint16_t qType = query.getQType();
+    bool rdataSet = false;
+
+    switch (qType)
     {
-        // cout << "[+] Domain in scope !" << endl;
+        case 1:
+        {
+            std::vector<uint8_t> bytes;
+            if (parseIPv4Address(domainName, bytes))
+            {
+                response.setAddressRdata(bytes);
+                rdataSet = true;
+            }
+            break;
+        }
+        case 28:
+        {
+            std::vector<uint8_t> bytes;
+            if (parseIPv6Address(domainName, bytes))
+            {
+                response.setAddressRdata(bytes);
+                rdataSet = true;
+            }
+            break;
+        }
+        case 5:
+        {
+            if (looksLikeDomainName(domainName))
+            {
+                response.setDomainRdata(domainName);
+                rdataSet = true;
+            }
+            break;
+        }
+        case 15:
+        {
+            std::string host = domainName;
+            std::optional<uint16_t> preference;
+            size_t spacePos = domainName.find(' ');
+            if (spacePos != std::string::npos)
+            {
+                preference = parsePreference(domainName.substr(0, spacePos));
+                host = domainName.substr(spacePos + 1);
+            }
 
-        response.setRCode(Response::Ok);
-        response.setRdLength(domainName.size()+2); // + initial label length & null label
-
-        response.setID( query.getID() );
-        response.setQdCount(1);
-        response.setAnCount(1);
-        response.setName( query.getQName() );
-        response.setType( query.getQType() );
-        response.setClass( query.getQClass() );
-        response.setRdata(domainName);
+            if (looksLikeDomainName(host))
+            {
+                Response::DomainRdata mx{host, preference};
+                response.setDomainRdata(mx);
+                rdataSet = true;
+            }
+            break;
+        }
+        case 16:
+        {
+            response.setTxtRdata(domainName);
+            rdataSet = true;
+            break;
+        }
+        default:
+            break;
     }
 
-    // text = "Resolver::process()";
-    // text += response.asString();
-    // logger.trace(text);
+    if (rdataSet)
+    {
+        response.setRCode(Response::Ok);
+        response.setAnCount(1);
+    }
+    else
+    {
+        response.setRCode(Response::ServerFailure);
+        response.clearRdata();
+    }
 }

--- a/tests/dns_test.cpp
+++ b/tests/dns_test.cpp
@@ -54,12 +54,12 @@ int main() {
     response.setName(query.getQName());
     response.setType(query.getQType());
     response.setClass(query.getQClass());
-    response.setRdata(serverHex);
+    response.setTxtRdata(serverHex);
 
     server.addQName(qname);
     std::string serverReceived = server.getMsg();
 
-    client.handle(response.getRdata());
+    client.handle(response.getRdataAsString());
     std::string clientReceived = client.getMsg();
 
     if (serverReceived != clientMsg) return 1;

--- a/tests/response_decode_test.cpp
+++ b/tests/response_decode_test.cpp
@@ -1,36 +1,81 @@
 #include <cassert>
 #include <string>
+#include <variant>
+#include <vector>
 
 #include "response.hpp"
 
 using namespace dns;
 
-int main() {
-    // Compressed DNS response for TXT record of example.com with "test" as data
+namespace
+{
+
+void testTxtDecode()
+{
     const unsigned char packet[] = {
-        0x00,0x00,  // ID
-        0x81,0x80,  // Flags
-        0x00,0x01,  // QDCOUNT
-        0x00,0x01,  // ANCOUNT
-        0x00,0x00,  // NSCOUNT
-        0x00,0x00,  // ARCOUNT
-        // Question section: example.com
+        0x00,0x00,
+        0x81,0x80,
+        0x00,0x01,
+        0x00,0x01,
+        0x00,0x00,
+        0x00,0x00,
         0x07,'e','x','a','m','p','l','e',
         0x03,'c','o','m',0x00,
-        0x00,0x10,  // QTYPE=TXT
-        0x00,0x01,  // QCLASS=IN
-        // Answer section: name pointer to offset 12 (0xC00C)
+        0x00,0x10,
+        0x00,0x01,
         0xC0,0x0C,
-        0x00,0x10,  // TYPE=TXT
-        0x00,0x01,  // CLASS=IN
-        0x00,0x00,0x00,0x00,  // TTL
-        0x00,0x04,  // RDLENGTH (length of text only, as expected by decoder)
-        0x04,'t','e','s','t' // TXT length and data
+        0x00,0x10,
+        0x00,0x01,
+        0x00,0x00,0x00,0x00,
+        0x00,0x05,
+        0x04,'t','e','s','t'
     };
 
     Response resp;
     resp.decode(reinterpret_cast<const char*>(packet), sizeof(packet));
+
     assert(resp.getName() == "example.com");
-    assert(resp.getRdata() == "test");
+    const auto& rdata = resp.getRdata();
+    assert(std::holds_alternative<Response::TxtRdata>(rdata));
+    const auto& txt = std::get<Response::TxtRdata>(rdata);
+    assert(txt.texts.size() == 1);
+    assert(txt.texts[0] == "test");
+    assert(resp.getRdataAsString() == "test");
+}
+
+
+void testAEncodeDecode()
+{
+    Response resp;
+    resp.setID(0);
+    resp.setQdCount(1);
+    resp.setAnCount(1);
+    resp.setName("example.com");
+    resp.setType(1);
+    resp.setClass(1);
+    resp.setTtl(300);
+    resp.setAddressRdata(std::vector<uint8_t>{192, 0, 2, 1});
+
+    char buffer[512] = {};
+    int size = resp.code(buffer);
+
+    Response decoded;
+    decoded.decode(buffer, size);
+
+    assert(decoded.getName() == "example.com");
+    const auto& rdata = decoded.getRdata();
+    assert(std::holds_alternative<Response::AddressRdata>(rdata));
+    auto bytes = std::get<Response::AddressRdata>(rdata).bytes;
+    assert(bytes == std::vector<uint8_t>({192, 0, 2, 1}));
+    assert(decoded.getRdataAsString() == "192.0.2.1");
+}
+
+}
+
+
+int main()
+{
+    testTxtDecode();
+    testAEncodeDecode();
     return 0;
 }


### PR DESCRIPTION
## Summary
- refactor the DNS response representation to store typed RDATA, including helpers for TXT, address, and domain encodings
- update server and client flows to infer record types, populate the typed RDATA, and surface decoded data consistently
- extend response decoding tests with a TXT fix and an A-record roundtrip to exercise the new encode/decode paths

## Testing
- cmake --build build
- ./build/tests/responseDecodeTest
- ./build/tests/testsDns
- ./build/tests/messageTest
- ./build/tests/utilsTest
- ./build/tests/interleavedTest
- ./build/tests/fonctionalTest


------
https://chatgpt.com/codex/tasks/task_e_68cea6865058832597c201c940d07976