### PR TITLE
Fix TXT record handling

### DIFF
--- a/src/response.cpp
+++ b/src/response.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <sstream>
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <set>
@@ -65,6 +66,8 @@ void Response::decode(const char* buffer, int size)
     decode_hdr(buffer);
     buffer += HDR_OFFSET;
 
+    m_rdata.clear();
+
     // query
     std::string respDom;
     decode_domain(buffer, respDom, begin, end);
@@ -79,20 +82,45 @@ void Response::decode(const char* buffer, int size)
     uint class_ = get16bits(buffer);
     m_ttl = get32bits(buffer);
 
-    if(type_ == 16)
+    m_type = type_;
+    m_class = class_;
+
+    if (type_ == 16)
     {
         m_rdLength = get16bits(buffer);
-        // skip la size ?
-        buffer++;
-        for (int i = 0; i < m_rdLength; i++) 
+
+        size_t remainingPacket = static_cast<size_t>(end - buffer);
+        size_t bytesToRead = std::min<size_t>(m_rdLength, remainingPacket);
+        const char* rdataEnd = buffer + bytesToRead;
+
+        while (buffer < rdataEnd)
         {
-            char c = *buffer++;
-            m_rdata.append(1, c);
+            uint8_t txtLength = static_cast<uint8_t>(*buffer++);
+            size_t available = static_cast<size_t>(rdataEnd - buffer);
+            size_t toCopy = std::min<size_t>(txtLength, available);
+
+            if (toCopy > 0)
+            {
+                m_rdata.append(buffer, toCopy);
+            }
+
+            buffer += toCopy;
+
+            if (toCopy < txtLength)
+            {
+                buffer = rdataEnd;
+                break;
+            }
         }
+
+        buffer = rdataEnd;
     }
     else
     {
-        // std::cout << "TODO: decode type diff than txt" << std::endl;
+        uint16_t rdLength = get16bits(buffer);
+        m_rdLength = rdLength;
+        size_t toSkip = std::min<size_t>(rdLength, static_cast<size_t>(end - buffer));
+        buffer += toSkip;
     }
 }
 
@@ -115,8 +143,35 @@ int Response::code(char* buffer)
     put16bits(buffer, m_type);
     put16bits(buffer, m_class);
     put32bits(buffer, m_ttl);
-    put16bits(buffer, m_rdLength);
-    code_domain(buffer, m_rdata);
+
+    char* rdlengthPtr = buffer;
+    buffer += 2;
+
+    uint requestedRdLength = m_rdLength;
+    uint rdlength = 0;
+    const char* dataPtr = m_rdata.data();
+    size_t remaining = m_rdata.size();
+
+    while (remaining > 0)
+    {
+        size_t chunkLen = std::min<size_t>(255, remaining);
+        *buffer++ = static_cast<char>(chunkLen);
+        std::memcpy(buffer, dataPtr, chunkLen);
+        buffer += chunkLen;
+        dataPtr += chunkLen;
+        remaining -= chunkLen;
+        rdlength += static_cast<uint>(chunkLen + 1);
+    }
+
+    if (rdlength == 0 && requestedRdLength > 0)
+    {
+        *buffer++ = 0;
+        rdlength = 1;
+    }
+
+    rdlengthPtr[0] = static_cast<char>((rdlength & 0xFF00) >> 8);
+    rdlengthPtr[1] = static_cast<char>(rdlength & 0x00FF);
+    m_rdLength = rdlength;
 
     int size = buffer - bufferBegin;
     log_buffer(bufferBegin, size);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -155,7 +155,19 @@ void Server::handleQuery(const Query& query, Response& response)
         // cout << "[+] Domain in scope !" << endl;
 
         response.setRCode(Response::Ok);
-        response.setRdLength(domainName.size()+2); // + initial label length & null label
+
+        std::string rawRdata = domainName;
+        rawRdata.erase(std::remove(rawRdata.begin(), rawRdata.end(), '.'), rawRdata.end());
+
+        size_t rdLength = 0;
+        for (size_t offset = 0; offset < rawRdata.size();)
+        {
+            size_t chunk = std::min<size_t>(255, rawRdata.size() - offset);
+            rdLength += chunk + 1; // chunk length + length octet
+            offset += chunk;
+        }
+
+        response.setRdLength(static_cast<uint>(rdLength));
 
         response.setID( query.getID() );
         response.setQdCount(1);
@@ -163,7 +175,7 @@ void Server::handleQuery(const Query& query, Response& response)
         response.setName( query.getQName() );
         response.setType( query.getQType() );
         response.setClass( query.getQClass() );
-        response.setRdata(domainName);
+        response.setRdata(rawRdata);
     }
 
     // text = "Resolver::process()";

--- a/tests/dns_test.cpp
+++ b/tests/dns_test.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cassert>
 #include <string>
 
@@ -8,6 +9,22 @@
 #include "dnsPacker.hpp"
 
 using namespace dns;
+
+static unsigned int calcTxtRdLength(const std::string& data)
+{
+    if (data.empty())
+        return 0;
+
+    unsigned int length = 0;
+    for (size_t offset = 0; offset < data.size();)
+    {
+        size_t chunk = std::min<size_t>(255, data.size() - offset);
+        length += static_cast<unsigned int>(chunk + 1);
+        offset += chunk;
+    }
+
+    return length;
+}
 
 class ClientEx : public Client {
 public:
@@ -47,7 +64,7 @@ int main() {
 
     Response response;
     response.setRCode(Response::Ok);
-    response.setRdLength(serverHex.size()+2);
+    response.setRdLength(calcTxtRdLength(serverHex));
     response.setID(query.getID());
     response.setQdCount(1);
     response.setAnCount(1);

--- a/tests/response_decode_test.cpp
+++ b/tests/response_decode_test.cpp
@@ -1,9 +1,27 @@
+#include <algorithm>
 #include <cassert>
+#include <cstring>
 #include <string>
 
 #include "response.hpp"
 
 using namespace dns;
+
+static unsigned int calcTxtRdLength(const std::string& data)
+{
+    if (data.empty())
+        return 0;
+
+    unsigned int length = 0;
+    for (size_t offset = 0; offset < data.size();)
+    {
+        size_t chunk = std::min<size_t>(255, data.size() - offset);
+        length += static_cast<unsigned int>(chunk + 1);
+        offset += chunk;
+    }
+
+    return length;
+}
 
 int main() {
     // Compressed DNS response for TXT record of example.com with "test" as data
@@ -24,7 +42,7 @@ int main() {
         0x00,0x10,  // TYPE=TXT
         0x00,0x01,  // CLASS=IN
         0x00,0x00,0x00,0x00,  // TTL
-        0x00,0x04,  // RDLENGTH (length of text only, as expected by decoder)
+        0x00,0x05,  // RDLENGTH (length octet + text)
         0x04,'t','e','s','t' // TXT length and data
     };
 
@@ -32,5 +50,68 @@ int main() {
     resp.decode(reinterpret_cast<const char*>(packet), sizeof(packet));
     assert(resp.getName() == "example.com");
     assert(resp.getRdata() == "test");
+
+    Response encodeResp;
+    encodeResp.setID(0);
+    encodeResp.setQdCount(1);
+    encodeResp.setAnCount(1);
+    encodeResp.setName("example.com");
+    encodeResp.setType(16);
+    encodeResp.setClass(1);
+    encodeResp.setTtl(0);
+    encodeResp.setRCode(Response::Ok);
+    std::string payload = "test";
+    encodeResp.setRdata(payload);
+    encodeResp.setRdLength(calcTxtRdLength(payload));
+
+    char buffer[256] = {0};
+    int encodedSize = encodeResp.code(buffer);
+    assert(static_cast<size_t>(encodedSize) == sizeof(packet));
+    assert(std::memcmp(buffer, packet, sizeof(packet)) == 0);
+
+    const unsigned char packetMulti[] = {
+        0x00,0x02,
+        0x81,0x80,
+        0x00,0x01,
+        0x00,0x01,
+        0x00,0x00,
+        0x00,0x00,
+        0x07,'e','x','a','m','p','l','e',
+        0x03,'c','o','m',0x00,
+        0x00,0x10,
+        0x00,0x01,
+        0xC0,0x0C,
+        0x00,0x10,
+        0x00,0x01,
+        0x00,0x00,0x00,0x00,
+        0x00,0x08,
+        0x03,'f','o','o',
+        0x03,'b','a','r'
+    };
+
+    Response multiResp;
+    multiResp.decode(reinterpret_cast<const char*>(packetMulti), sizeof(packetMulti));
+    assert(multiResp.getRdata() == "foobar");
+
+    std::string longPayload(300, 'A');
+    Response roundTrip;
+    roundTrip.setID(0x1234);
+    roundTrip.setQdCount(1);
+    roundTrip.setAnCount(1);
+    roundTrip.setName("example.com");
+    roundTrip.setType(16);
+    roundTrip.setClass(1);
+    roundTrip.setTtl(0);
+    roundTrip.setRCode(Response::Ok);
+    roundTrip.setRdata(longPayload);
+    roundTrip.setRdLength(calcTxtRdLength(longPayload));
+
+    char roundTripBuffer[1024] = {0};
+    int roundTripSize = roundTrip.code(roundTripBuffer);
+
+    Response decodedRoundTrip;
+    decodedRoundTrip.decode(roundTripBuffer, roundTripSize);
+    assert(decodedRoundTrip.getRdata() == longPayload);
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- compute TXT TXT RDATA lengths in the server success path and strip dots before storing the payload
- encode and decode TXT answers as length-prefixed strings instead of domain labels
- add coverage for TXT encode/decode including round-trip validation and update DNS test length math

## Testing
- cmake --build build
- ./build/tests/responseDecodeTest
- ./build/tests/testsDns
- ./build/tests/utilsTest
- ./build/tests/messageTest
- ./build/tests/interleavedTest

------
https://chatgpt.com/codex/tasks/task_e_68cea68549b4832588a92869aaf83ebf