### PR TITLE
Fix NXDOMAIN response encoding and add regression test

### DIFF
--- a/src/response.cpp
+++ b/src/response.cpp
@@ -65,34 +65,44 @@ void Response::decode(const char* buffer, int size)
     decode_hdr(buffer);
     buffer += HDR_OFFSET;
 
+    m_rdata.clear();
+    m_rdLength = 0;
+    m_ttl = 0;
+
     // query
     std::string respDom;
-    decode_domain(buffer, respDom, begin, end);
-    m_name = respDom;
-    m_type = get16bits(buffer);
-    m_class = get16bits(buffer);
+    if (m_qdCount > 0)
+    {
+        decode_domain(buffer, respDom, begin, end);
+        m_name = respDom;
+        m_type = get16bits(buffer);
+        m_class = get16bits(buffer);
+    }
 
     // answer
-    decode_domain(buffer, respDom, begin, end);
-    m_name = respDom;
-    uint type_ = get16bits(buffer);
-    uint class_ = get16bits(buffer);
-    m_ttl = get32bits(buffer);
+    if (m_anCount > 0)
+    {
+        decode_domain(buffer, respDom, begin, end);
+        m_name = respDom;
+        uint type_ = get16bits(buffer);
+        uint class_ = get16bits(buffer);
+        m_ttl = get32bits(buffer);
 
-    if(type_ == 16)
-    {
-        m_rdLength = get16bits(buffer);
-        // skip la size ?
-        buffer++;
-        for (int i = 0; i < m_rdLength; i++) 
+        if(type_ == 16)
         {
-            char c = *buffer++;
-            m_rdata.append(1, c);
+            m_rdLength = get16bits(buffer);
+            // skip la size ?
+            buffer++;
+            for (int i = 0; i < m_rdLength && buffer < end; i++)
+            {
+                char c = *buffer++;
+                m_rdata.append(1, c);
+            }
         }
-    }
-    else
-    {
-        // std::cout << "TODO: decode type diff than txt" << std::endl;
+        else
+        {
+            // std::cout << "TODO: decode type diff than txt" << std::endl;
+        }
     }
 }
 
@@ -105,18 +115,24 @@ int Response::code(char* buffer)
     buffer += HDR_OFFSET;
 
     // Code Question section
-    code_domain(buffer, m_name);
-    put16bits(buffer, m_type);
-    put16bits(buffer, m_class);
+    if (m_qdCount > 0)
+    {
+        code_domain(buffer, m_name);
+        put16bits(buffer, m_type);
+        put16bits(buffer, m_class);
+    }
 
     // Code Answer section
-    put16bits(buffer, 49164);
-    // code_domain(buffer, m_name);
-    put16bits(buffer, m_type);
-    put16bits(buffer, m_class);
-    put32bits(buffer, m_ttl);
-    put16bits(buffer, m_rdLength);
-    code_domain(buffer, m_rdata);
+    if (m_anCount > 0)
+    {
+        put16bits(buffer, 49164);
+        // code_domain(buffer, m_name);
+        put16bits(buffer, m_type);
+        put16bits(buffer, m_class);
+        put32bits(buffer, m_ttl);
+        put16bits(buffer, m_rdLength);
+        code_domain(buffer, m_rdata);
+    }
 
     int size = buffer - bufferBegin;
     log_buffer(bufferBegin, size);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -139,16 +139,19 @@ void Server::handleQuery(const Query& query, Response& response)
 
     // std::cout << "domainName " << domainName << std::endl;
     
-    if (domainName.empty()) 
+    if (domainName.empty())
     {
         // cout << "[-] Domain not in scope !" << endl;
 
         response.setID( query.getID() );
+        response.setQdCount(1);
+        response.setAnCount(0);
+        response.setNsCount(0);
         response.setName( query.getQName() );
         response.setType( query.getQType() );
         response.setClass( query.getQClass() );
         response.setRCode(Response::NameError);
-        response.setRdLength(1); // null label
+        response.setRdLength(0);
     }
     else 
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,16 @@ else()
 endif()
 
 
+add_executable(nameErrorResponseTest "name_error_response_test.cpp" )
+set_property(TARGET nameErrorResponseTest PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
+
+if(WIN32)
+        target_link_libraries(nameErrorResponseTest Dnscommunication)
+else()
+        target_link_libraries(nameErrorResponseTest Dnscommunication pthread)
+endif()
+
+
 add_executable(messageTest "message_test.cpp" )
 set_property(TARGET messageTest PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
 

--- a/tests/name_error_response_test.cpp
+++ b/tests/name_error_response_test.cpp
@@ -1,0 +1,54 @@
+#include <cassert>
+#include <string>
+
+#include "response.hpp"
+
+using namespace dns;
+
+namespace {
+size_t encodedDomainLength(const std::string& domain) {
+    size_t length = 1; // null terminator
+    size_t start = 0;
+    while (start < domain.size()) {
+        size_t end = domain.find('.', start);
+        if (end == std::string::npos) {
+            end = domain.size();
+        }
+        length += 1 + (end - start);
+        start = end + 1;
+    }
+    return length;
+}
+}
+
+int main() {
+    const std::string domain = "example.com";
+
+    Response resp;
+    resp.setID(0x1234);
+    resp.setQdCount(1);
+    resp.setAnCount(0);
+    resp.setNsCount(0);
+    resp.setName(domain);
+    resp.setType(16); // TXT
+    resp.setClass(1); // IN
+    resp.setRCode(Response::NameError);
+    resp.setRdLength(0);
+
+    char buffer[512] = {};
+    int size = resp.code(buffer);
+
+    const size_t expectedSize = 12 + encodedDomainLength(domain) + 4; // header + question
+    assert(size == static_cast<int>(expectedSize));
+
+    Response decoded;
+    decoded.decode(buffer, size);
+
+    assert(decoded.getQdCount() == 1);
+    assert(decoded.getAnCount() == 0);
+    assert(decoded.getNsCount() == 0);
+    assert(decoded.getName() == domain);
+    assert(decoded.getRdata().empty());
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- ensure NXDOMAIN responses set header counts and suppress answer data
- guard response encoding/decoding so the answer section is only emitted when ANCOUNT > 0
- add a regression test that decodes a NameError response and verifies the header counts

## Testing
- cmake --build build
- ./build/tests/nameErrorResponseTest
- ./build/tests/responseDecodeTest

------
https://chatgpt.com/codex/tasks/task_e_68cea684be1c8325ad5c16157f7dc3fa