### PR TITLE
Improve DNS record handling and add public client example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,17 @@ if(DNS_ENABLE_LOGGING)
 endif()
 if(WIN32)
 else()
-	target_link_libraries(${PROJECT_NAME} pthread)
+        target_link_libraries(${PROJECT_NAME} pthread)
+endif()
+
+
+add_executable(publicDnsClient "examples/public_dns_client.cpp" )
+set_property(TARGET publicDnsClient PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded")
+
+if(WIN32)
+        target_link_libraries(publicDnsClient Dnscommunication)
+else()
+        target_link_libraries(publicDnsClient Dnscommunication pthread)
 endif()
 
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ It encodes arbitrary data into DNS TXT records so a client and server can exchan
 ## Features
 - UDP DNS client and server implementation.
 - Message fragmentation and reassembly using JSON and hex encoding.
+- TXT, CNAME, MX, A and AAAA records handled consistently for both encoding and decoding.
 - Random subdomain generation and utility helpers.
 - Cross-platform support for Linux and Windows.
 
@@ -66,6 +67,17 @@ You can test locally without a real DNS server:
 If the message is received correctly, the client will print `EXPECTATION OK` and exit with code `0`.
 
 This setup is useful for **CI pipelines** or quick validation without relying on external resolvers.
+
+### Querying a public resolver
+
+The repository also provides a tiny helper that sends a raw DNS query to any resolver and decodes the answer with the library:
+
+```bash
+cmake --build build --target publicDnsClient
+./publicDnsClient 8.8.8.8 example.com TXT
+```
+
+Any RR type supported by the library can be supplied as the optional third argument (for example `CNAME`, `MX`, `AAAA`, …). The tool prints the textual view of the first answer as well as the raw hexadecimal payload, which makes it easy to verify interoperability with public DNS services.
 
 ---
 

--- a/examples/public_dns_client.cpp
+++ b/examples/public_dns_client.cpp
@@ -1,0 +1,211 @@
+#include <chrono>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#ifdef __linux__
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#elif _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
+#endif
+
+#include "query.hpp"
+#include "response.hpp"
+
+namespace
+{
+
+uint16_t parse_type(const std::string& value)
+{
+    if (value == "A") return 1;
+    if (value == "NS") return 2;
+    if (value == "CNAME") return 5;
+    if (value == "SOA") return 6;
+    if (value == "PTR") return 12;
+    if (value == "MX") return 15;
+    if (value == "TXT") return 16;
+    if (value == "AAAA") return 28;
+    if (value == "SRV") return 33;
+    try
+    {
+        int parsed = std::stoi(value);
+        if (parsed < 0 || parsed > 65535)
+            throw std::out_of_range("type out of range");
+        return static_cast<uint16_t>(parsed);
+    }
+    catch (...)
+    {
+        throw std::invalid_argument("Unsupported RR type '" + value + "'");
+    }
+}
+
+void print_usage()
+{
+    std::cerr << "Usage: public_dns_client <resolver-ip> <name> [type]" << std::endl;
+    std::cerr << "Example: public_dns_client 8.8.8.8 example.com TXT" << std::endl;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    if (argc < 3)
+    {
+        print_usage();
+        return 1;
+    }
+
+    const std::string resolver = argv[1];
+    const std::string qname = argv[2];
+    const std::string typeStr = (argc >= 4) ? argv[3] : std::string("TXT");
+
+    uint16_t qtype = 16;
+    try
+    {
+        qtype = parse_type(typeStr);
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << ex.what() << std::endl;
+        return 1;
+    }
+
+#ifdef _WIN32
+    WSADATA wsa{};
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+    {
+        std::cerr << "WSAStartup failed" << std::endl;
+        return 1;
+    }
+#endif
+
+#ifdef _WIN32
+    SOCKET sock = INVALID_SOCKET;
+#else
+    int sock = -1;
+#endif
+    try
+    {
+        sock = socket(AF_INET, SOCK_DGRAM, 0);
+#ifdef _WIN32
+        if (sock == INVALID_SOCKET)
+            throw std::runtime_error("socket() failed");
+#else
+        if (sock < 0)
+            throw std::runtime_error("socket() failed");
+#endif
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = htons(53);
+#ifdef __linux__
+        if (inet_pton(AF_INET, resolver.c_str(), &addr.sin_addr) != 1)
+            throw std::runtime_error("inet_pton failed for resolver");
+#elif _WIN32
+        if (InetPtonA(AF_INET, resolver.c_str(), &addr.sin_addr) != 1)
+            throw std::runtime_error("InetPton failed for resolver");
+#endif
+
+        dns::Query query;
+        auto nowTicks = static_cast<uint16_t>(std::chrono::steady_clock::now().time_since_epoch().count() & 0xFFFF);
+        query.setID(nowTicks);
+        query.setQName(qname);
+        query.setQType(qtype);
+        query.setQClass(1);
+        query.setQdCount(1);
+        query.setAnCount(0);
+        query.setNsCount(0);
+        query.setArCount(0);
+
+        char sendBuf[512];
+        const int qlen = query.code(sendBuf);
+
+        int sent = sendto(sock, sendBuf, qlen, 0, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+#ifdef _WIN32
+        if (sent == SOCKET_ERROR)
+            throw std::runtime_error("sendto() failed");
+#else
+        if (sent != qlen)
+            throw std::runtime_error("sendto() failed");
+#endif
+
+        char recvBuf[1024];
+#ifdef __linux__
+        const int received = recvfrom(sock, recvBuf, sizeof(recvBuf), 0, nullptr, nullptr);
+#elif _WIN32
+        int addrLen = sizeof(addr);
+        const int received = recvfrom(sock, recvBuf, sizeof(recvBuf), 0, reinterpret_cast<sockaddr*>(&addr), &addrLen);
+#endif
+        if (received <= 0)
+            throw std::runtime_error("recvfrom() failed");
+
+        dns::Response response;
+        response.decode(recvBuf, received);
+
+        std::cout << "Response ID: 0x" << std::hex << std::setw(4) << std::setfill('0')
+                  << response.getID() << std::dec << std::setfill(' ') << std::endl;
+        std::cout << "Question: " << response.getQuestionName() << std::endl;
+        std::cout << "Answer name: " << response.getName() << std::endl;
+        std::cout << "RDATA (text): " << response.getRdata() << std::endl;
+
+        const auto& raw = response.getRdataBytes();
+        if (!raw.empty())
+        {
+            std::cout << "RDATA (hex):";
+            for (auto byte : raw)
+                std::cout << ' ' << std::hex << std::setw(2) << std::setfill('0')
+                          << static_cast<int>(byte);
+            std::cout << std::dec << std::setfill(' ') << std::endl;
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << "Error: " << ex.what() << std::endl;
+        if (
+#ifdef _WIN32
+            sock != INVALID_SOCKET
+#else
+            sock >= 0
+#endif
+        )
+        {
+#ifdef __linux__
+            close(sock);
+#elif _WIN32
+            closesocket(sock);
+#endif
+        }
+#ifdef _WIN32
+        WSACleanup();
+#endif
+        return 1;
+    }
+
+    if (
+#ifdef _WIN32
+        sock != INVALID_SOCKET
+#else
+        sock >= 0
+#endif
+    )
+    {
+#ifdef __linux__
+        close(sock);
+#elif _WIN32
+        closesocket(sock);
+#endif
+    }
+
+#ifdef _WIN32
+    WSACleanup();
+#endif
+
+    return 0;
+}

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -65,12 +65,13 @@ void Message::decode_hdr(const char* buffer)
     m_id = get16bits(buffer);
 
     uint fields = get16bits(buffer);
-    m_qr = fields & QR_MASK;
-    m_opcode = fields & OPCODE_MASK;
-    m_aa = fields & AA_MASK;
-    m_tc = fields & TC_MASK;
-    m_rd = fields & RD_MASK;
+    m_qr = (fields & QR_MASK) ? 1U : 0U;
+    m_opcode = (fields & OPCODE_MASK) >> 11;
+    m_aa = (fields & AA_MASK) ? 1U : 0U;
+    m_tc = (fields & TC_MASK) ? 1U : 0U;
+    m_rd = (fields & RD_MASK) ? 1U : 0U;
     m_ra = (fields & RA_MASK) >> 7;
+    m_rcode = fields & RCODE_MASK;
 
     m_qdCount = get16bits(buffer);
     m_anCount = get16bits(buffer);
@@ -83,13 +84,14 @@ void Message::code_hdr(char* buffer)
 {
     put16bits(buffer, m_id);
 
-    int fields = 0;
-    fields += (m_qr << 15);
-    // fields += (m_opcode << 14);
-    fields += (m_aa << 10);
-    fields += (m_tc << 9);
-    fields += (m_rd << 8);
-    fields += (m_ra << 7);
+    uint16_t fields = 0;
+    fields |= (m_qr & 0x1U) << 15;
+    fields |= (m_opcode & 0xFU) << 11;
+    fields |= (m_aa & 0x1U) << 10;
+    fields |= (m_tc & 0x1U) << 9;
+    fields |= (m_rd & 0x1U) << 8;
+    fields |= (m_ra & 0x1U) << 7;
+    fields |= (m_rcode & 0xFU);
     put16bits(buffer, fields);
 
     put16bits(buffer, m_qdCount);

--- a/src/message.hpp
+++ b/src/message.hpp
@@ -54,6 +54,11 @@ public:
     uint getNsCount() const { return m_nsCount; }
     uint getArCount() const { return m_arCount; }
 
+    bool isResponse() const { return m_qr != 0; }
+    bool isRecursionDesired() const { return m_rd != 0; }
+
+    void setRecursionDesired(bool value) { m_rd = value ? 1U : 0U; }
+
     void setID(uint id) { m_id = id; }
     void setQdCount(uint count) { m_qdCount = count; }
     void setAnCount(uint count) { m_anCount = count; }
@@ -72,9 +77,9 @@ protected:
     uint m_aa;          // authoritive answer
     uint m_tc;          // truncated message
     uint m_rd;          // recursion desired
-    uint m_ra;
+    uint m_ra;          // recursion available
 
-    uint m_rcode;
+    uint m_rcode;       // response code
     
     uint m_qdCount;
     uint m_anCount;

--- a/src/response.cpp
+++ b/src/response.cpp
@@ -1,8 +1,7 @@
-#include <iostream>
-#include <sstream>
-#include <cstdint>
+#include <algorithm>
 #include <cstring>
 #include <set>
+#include <sstream>
 
 #ifdef __linux__
 
@@ -22,108 +21,274 @@
 using namespace std;
 using namespace dns;
 
+namespace
+{
 
-Response::Response() 
-: Message(Message::Response) 
-{ 
-    m_name="";
-    m_type=0;
-    m_class=0;
-    m_ttl=0;
-    m_rdLength=0;
-    m_rdata="";
+/// Helper to convert two bytes to a 16-bit unsigned integer without advancing the pointer.
+static uint16_t peek16(const char* data)
+{
+    return static_cast<uint16_t>(static_cast<uint8_t>(data[0]) << 8 |
+                                 static_cast<uint8_t>(data[1]));
 }
 
-
-Response::~Response() 
-{ 
+static int hex_value(char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
+    return -1;
 }
 
+static std::vector<uint8_t> hex_to_bytes(const std::string& hex)
+{
+    if (hex.size() % 2 != 0)
+        return {};
 
-string Response::asString() const 
+    std::vector<uint8_t> bytes;
+    bytes.reserve(hex.size() / 2);
+    for (size_t i = 0; i < hex.size(); i += 2)
+    {
+        int high = hex_value(hex[i]);
+        int low = hex_value(hex[i + 1]);
+        if (high < 0 || low < 0)
+            return {};
+        bytes.push_back(static_cast<uint8_t>((high << 4) | low));
+    }
+    return bytes;
+}
+
+static std::string bytes_to_hex(const char* data, size_t length)
+{
+    static const char* digits = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(length * 2);
+    for (size_t i = 0; i < length; ++i)
+    {
+        unsigned char byte = static_cast<unsigned char>(data[i]);
+        out.push_back(digits[byte >> 4]);
+        out.push_back(digits[byte & 0x0F]);
+    }
+    return out;
+}
+
+} // namespace
+
+Response::Response()
+: Message(Message::Response)
+, m_questionType(0)
+, m_questionClass(0)
+, m_answerType(0)
+, m_answerClass(0)
+, m_ttl(0)
+, m_rdLength(0)
+, m_mxPreference(0)
+{}
+
+Response::~Response() = default;
+
+void Response::setName(const std::string& value)
+{
+    m_questionName = value;
+    m_answerName = value;
+}
+
+void Response::setAnswerName(const std::string& value)
+{
+    m_answerName = value;
+}
+
+void Response::setType(const uint value)
+{
+    m_questionType = value;
+    m_answerType = value;
+}
+
+void Response::setClass(const uint value)
+{
+    m_questionClass = value;
+    m_answerClass = value;
+}
+
+void Response::setRdata(const std::string& value)
+{
+    m_rdata = value;
+    m_rdataBinary.clear();
+    m_txtStrings.clear();
+}
+
+void Response::setRdataBytes(const std::vector<uint8_t>& data)
+{
+    m_rdataBinary = data;
+    m_rdata.assign(data.begin(), data.end());
+    m_txtStrings.clear();
+    m_rdLength = static_cast<uint>(data.size());
+}
+
+void Response::clearAnswer()
+{
+    m_anCount = 0;
+    m_answerName.clear();
+    m_answerType = 0;
+    m_answerClass = 0;
+    m_ttl = 0;
+    m_rdLength = 0;
+    m_rdata.clear();
+    m_rdataBinary.clear();
+    m_txtStrings.clear();
+    m_mxPreference = 0;
+}
+
+string Response::asString() const
 {
     ostringstream text;
     text << endl << "RESPONSE { ";
     text << Message::asString();
 
-    text << "\tname: " << m_name << endl;
-    text << "\ttype: " << m_type << endl;
-    text << "\tclass: " << m_class << endl;
+    text << "\tqname: " << m_questionName << endl;
+    text << "\tqtype: " << m_questionType << endl;
+    text << "\tqclass: " << m_questionClass << endl;
+
+    text << "\tanswerName: " << m_answerName << endl;
+    text << "\tanswerType: " << m_answerType << endl;
+    text << "\tanswerClass: " << m_answerClass << endl;
     text << "\tttl: " << m_ttl << endl;
     text << "\trdLength: " << m_rdLength << endl;
-    text << "\trdata: " << m_rdata << " }" << dec;
+    text << "\tmxPreference: " << m_mxPreference << endl;
+    text << "\trdata (text): " << m_rdata << " }" << dec;
 
     return text.str();
 }
-
 
 void Response::decode(const char* buffer, int size)
 {
     const char* begin = buffer;
     const char* end = buffer + size;
 
+    m_questionName.clear();
+    m_answerName.clear();
+    m_rdata.clear();
+    m_rdataBinary.clear();
+    m_txtStrings.clear();
+    m_mxPreference = 0;
+    m_rdLength = 0;
+    m_questionType = 0;
+    m_questionClass = 0;
+    m_answerType = 0;
+    m_answerClass = 0;
+    m_ttl = 0;
+
+    if (size < static_cast<int>(HDR_OFFSET))
+        return;
+
     decode_hdr(buffer);
-    buffer += HDR_OFFSET;
+    const char* cursor = begin + HDR_OFFSET;
 
-    // query
-    std::string respDom;
-    decode_domain(buffer, respDom, begin, end);
-    m_name = respDom;
-    m_type = get16bits(buffer);
-    m_class = get16bits(buffer);
-
-    // answer
-    decode_domain(buffer, respDom, begin, end);
-    m_name = respDom;
-    uint type_ = get16bits(buffer);
-    uint class_ = get16bits(buffer);
-    m_ttl = get32bits(buffer);
-
-    if(type_ == 16)
-    {
-        m_rdLength = get16bits(buffer);
-        // skip la size ?
-        buffer++;
-        for (int i = 0; i < m_rdLength; i++) 
+    auto safe_get16 = [&](const char*& ptr) -> uint16_t {
+        if (ptr + 2 > end)
         {
-            char c = *buffer++;
-            m_rdata.append(1, c);
+            ptr = end;
+            return 0;
+        }
+        return static_cast<uint16_t>(get16bits(ptr));
+    };
+
+    auto safe_get32 = [&](const char*& ptr) -> uint32_t {
+        if (ptr + 4 > end)
+        {
+            ptr = end;
+            return 0;
+        }
+        return static_cast<uint32_t>(get32bits(ptr));
+    };
+
+    for (uint i = 0; i < m_qdCount && cursor < end; ++i)
+    {
+        std::string qname;
+        decode_domain(cursor, qname, begin, end);
+        uint16_t qtype = safe_get16(cursor);
+        uint16_t qclass = safe_get16(cursor);
+        if (i == 0)
+        {
+            m_questionName = qname;
+            m_questionType = qtype;
+            m_questionClass = qclass;
         }
     }
-    else
+
+    for (uint i = 0; i < m_anCount && cursor < end; ++i)
     {
-        // std::cout << "TODO: decode type diff than txt" << std::endl;
+        std::string name;
+        decode_domain(cursor, name, begin, end);
+        uint16_t type = safe_get16(cursor);
+        uint16_t klass = safe_get16(cursor);
+        uint32_t ttl = safe_get32(cursor);
+        uint16_t rdlength = safe_get16(cursor);
+        if (cursor + rdlength > end)
+        {
+            rdlength = static_cast<uint16_t>(std::max<long>(0, end - cursor));
+        }
+
+        if (i == 0)
+        {
+            m_answerName = name;
+            m_answerType = type;
+            m_answerClass = klass;
+            m_ttl = ttl;
+            parse_rdata(type, cursor, rdlength, begin, end);
+        }
+
+        cursor += rdlength;
+    }
+
+    for (uint i = 0; i < m_nsCount && cursor < end; ++i)
+    {
+        skip_record(cursor, begin, end);
+    }
+
+    for (uint i = 0; i < m_arCount && cursor < end; ++i)
+    {
+        skip_record(cursor, begin, end);
     }
 }
 
-
-int Response::code(char* buffer) 
+int Response::code(char* buffer)
 {
     char* bufferBegin = buffer;
 
     code_hdr(buffer);
     buffer += HDR_OFFSET;
 
-    // Code Question section
-    code_domain(buffer, m_name);
-    put16bits(buffer, m_type);
-    put16bits(buffer, m_class);
+    if (m_qdCount > 0 && !m_questionName.empty())
+    {
+        code_domain(buffer, m_questionName);
+        put16bits(buffer, m_questionType);
+        put16bits(buffer, m_questionClass);
+    }
 
-    // Code Answer section
-    put16bits(buffer, 49164);
-    // code_domain(buffer, m_name);
-    put16bits(buffer, m_type);
-    put16bits(buffer, m_class);
-    put32bits(buffer, m_ttl);
-    put16bits(buffer, m_rdLength);
-    code_domain(buffer, m_rdata);
+    if (m_anCount > 0)
+    {
+        const std::string owner = m_answerName.empty() ? m_questionName : m_answerName;
+        code_domain(buffer, owner);
+        put16bits(buffer, m_answerType);
+        put16bits(buffer, m_answerClass);
+        put32bits(buffer, m_ttl);
 
-    int size = buffer - bufferBegin;
+        std::vector<uint8_t> rdata = build_rdata();
+        m_rdLength = static_cast<uint>(rdata.size());
+        m_rdataBinary = rdata;
+        put16bits(buffer, m_rdLength);
+        if (!rdata.empty())
+        {
+            std::memcpy(buffer, rdata.data(), rdata.size());
+            buffer += rdata.size();
+        }
+    }
+
+    int size = static_cast<int>(buffer - bufferBegin);
     log_buffer(bufferBegin, size);
 
     return size;
 }
-
 
 void Response::decode_domain(const char*& buffer, std::string& domain,
                              const char* begin, const char* end)
@@ -134,19 +299,23 @@ void Response::decode_domain(const char*& buffer, std::string& domain,
     bool jumped = false;
     std::set<const char*> visited;
 
-    while (cur < end) {
+    while (cur < end)
+    {
         uint8_t len = static_cast<uint8_t>(*cur);
 
-        if ((len & 0xC0) == 0xC0) {
+        if ((len & 0xC0) == 0xC0)
+        {
             if (cur + 1 >= end) { buffer = end; return; }
             uint16_t offset = ((len & 0x3F) << 8) | static_cast<uint8_t>(cur[1]);
             const char* ptr = begin + offset;
-            if (ptr < begin || ptr >= end || visited.count(ptr)) {
+            if (ptr < begin || ptr >= end || visited.count(ptr))
+            {
                 buffer = end;
                 return;
             }
             visited.insert(ptr);
-            if (!jumped) {
+            if (!jumped)
+            {
                 buffer = cur + 2;
                 jumped = true;
             }
@@ -154,7 +323,8 @@ void Response::decode_domain(const char*& buffer, std::string& domain,
             continue;
         }
 
-        if (len == 0) {
+        if (len == 0)
+        {
             ++cur;
             if (!jumped) buffer = cur;
             return;
@@ -170,27 +340,260 @@ void Response::decode_domain(const char*& buffer, std::string& domain,
     buffer = end;
 }
 
-
-void Response::code_domain(char*& buffer, const std::string& domain) 
+void Response::code_domain(char*& buffer, const std::string& domain)
 {
-    int start(0), end; // indexes
-
-    while ((end = domain.find('.', start)) != string::npos) 
+    if (domain.empty())
     {
-
-        *buffer++ = end - start; // label length octet
-        for (int i=start; i<end; i++) {
-
-            *buffer++ = domain[i]; // label octets
-        }
-        start = end + 1; // Skip '.'
+        *buffer++ = 0;
+        return;
     }
 
-    *buffer++ = domain.size() - start; // last label length octet
-    for (int i=start; i<domain.size(); i++) {
+    int start = 0;
+    int end = 0;
 
-        *buffer++ = domain[i]; // last label octets
+    while (start < static_cast<int>(domain.size()))
+    {
+        end = domain.find('.', start);
+        if (end == std::string::npos)
+            end = static_cast<int>(domain.size());
+
+        int labelLen = end - start;
+        int processed = 0;
+        while (processed < labelLen)
+        {
+            int chunkLen = std::min(63, labelLen - processed);
+            *buffer++ = static_cast<char>(chunkLen);
+            for (int i = 0; i < chunkLen; ++i)
+            {
+                *buffer++ = domain[start + processed + i];
+            }
+            processed += chunkLen;
+        }
+
+        start = end + 1;
     }
 
     *buffer++ = 0;
 }
+
+void Response::parse_rdata(uint16_t type, const char* data, uint16_t length,
+                           const char* begin, const char* end)
+{
+    m_rdLength = length;
+    m_rdataBinary.assign(data, data + length);
+    m_rdata.clear();
+    m_txtStrings.clear();
+
+    switch (type)
+    {
+        case 16: // TXT
+        {
+            const char* ptr = data;
+            uint16_t remaining = length;
+            std::string combined;
+
+            while (remaining > 0)
+            {
+                uint8_t chunkLen = static_cast<uint8_t>(*ptr++);
+                --remaining;
+                if (chunkLen > remaining)
+                    chunkLen = remaining;
+
+                std::string piece(ptr, ptr + chunkLen);
+                m_txtStrings.push_back(piece);
+                combined.append(piece);
+                ptr += chunkLen;
+                remaining -= chunkLen;
+            }
+
+            if (length == 0)
+                m_txtStrings.emplace_back();
+
+            m_rdata = combined;
+            break;
+        }
+        case 5:  // CNAME
+        case 2:  // NS
+        case 12: // PTR
+        {
+            const char* ptr = data;
+            decode_domain(ptr, m_rdata, begin, end);
+            break;
+        }
+        case 15: // MX
+        {
+            if (length >= 2)
+            {
+                m_mxPreference = peek16(data);
+                const char* ptr = data + 2;
+                decode_domain(ptr, m_rdata, begin, end);
+            }
+            else
+            {
+                m_mxPreference = 0;
+                m_rdata.clear();
+            }
+            break;
+        }
+        case 1: // A
+        {
+            if (length == 4)
+                // Convert IPv4 bytes to hex so the tunneling logic can
+                // reassemble the payload without additional parsing.
+                m_rdata = bytes_to_hex(data, length);
+            break;
+        }
+        case 28: // AAAA
+        {
+            if (length == 16)
+                // Same strategy for IPv6: expose the raw bytes as hex.
+                m_rdata = bytes_to_hex(data, length);
+            break;
+        }
+        default:
+        {
+            m_rdata.assign(data, data + length);
+            break;
+        }
+    }
+}
+
+std::vector<uint8_t> Response::build_rdata() const
+{
+    if (!m_rdataBinary.empty())
+        return m_rdataBinary;
+
+    switch (m_answerType)
+    {
+        case 16:
+            return encode_txt_rdata(m_rdata);
+        case 5:
+        case 2:
+        case 12:
+            return encode_domain_rdata(m_rdata);
+        case 15:
+            return encode_mx_rdata(m_mxPreference, m_rdata);
+        case 1:
+            return encode_address_rdata(AF_INET, m_rdata);
+        case 28:
+            return encode_address_rdata(AF_INET6, m_rdata);
+        default:
+            return std::vector<uint8_t>(m_rdata.begin(), m_rdata.end());
+    }
+}
+
+std::vector<uint8_t> Response::encode_domain_rdata(const std::string& domain) const
+{
+    std::vector<uint8_t> out;
+    if (domain.empty())
+    {
+        out.push_back(0);
+        return out;
+    }
+
+    size_t start = 0;
+    while (start < domain.size())
+    {
+        size_t dot = domain.find('.', start);
+        if (dot == std::string::npos)
+            dot = domain.size();
+
+        std::string label = domain.substr(start, dot - start);
+        size_t consumed = 0;
+        while (consumed < label.size())
+        {
+            size_t chunk = std::min<size_t>(63, label.size() - consumed);
+            out.push_back(static_cast<uint8_t>(chunk));
+            out.insert(out.end(), label.begin() + consumed, label.begin() + consumed + chunk);
+            consumed += chunk;
+        }
+
+        start = dot + 1;
+    }
+
+    out.push_back(0);
+    return out;
+}
+
+std::vector<uint8_t> Response::encode_txt_rdata(const std::string& text) const
+{
+    std::vector<uint8_t> out;
+    if (text.empty())
+    {
+        out.push_back(0);
+        return out;
+    }
+
+    size_t pos = 0;
+    while (pos < text.size())
+    {
+        size_t chunk = std::min<size_t>(255, text.size() - pos);
+        out.push_back(static_cast<uint8_t>(chunk));
+        out.insert(out.end(), text.begin() + pos, text.begin() + pos + chunk);
+        pos += chunk;
+    }
+
+    return out;
+}
+
+std::vector<uint8_t> Response::encode_mx_rdata(uint16_t preference, const std::string& exchange) const
+{
+    std::vector<uint8_t> domain = encode_domain_rdata(exchange);
+    std::vector<uint8_t> out;
+    out.reserve(domain.size() + 2);
+    out.push_back(static_cast<uint8_t>((preference >> 8) & 0xFF));
+    out.push_back(static_cast<uint8_t>(preference & 0xFF));
+    out.insert(out.end(), domain.begin(), domain.end());
+    return out;
+}
+
+std::vector<uint8_t> Response::encode_address_rdata(int family, const std::string& address) const
+{
+    size_t expected = (family == AF_INET) ? 4 : (family == AF_INET6 ? 16 : 0);
+    if (expected == 0)
+        return {};
+
+    bool looksHex = !address.empty() &&
+                    address.find_first_not_of("0123456789abcdefABCDEF") == std::string::npos &&
+                    address.size() == expected * 2;
+    if (looksHex)
+        return hex_to_bytes(address);
+
+    std::vector<uint8_t> out(expected);
+#ifdef _WIN32
+    if (InetPtonA(family, address.c_str(), out.data()) != 1)
+        return {};
+#else
+    if (inet_pton(family, address.c_str(), out.data()) != 1)
+        return {};
+#endif
+    return out;
+}
+
+void Response::skip_record(const char*& buffer, const char* begin, const char* end)
+{
+    if (buffer >= end)
+        return;
+
+    std::string name;
+    decode_domain(buffer, name, begin, end);
+
+    if (buffer + 10 > end)
+    {
+        buffer = end;
+        return;
+    }
+
+    buffer += 2; // type
+    buffer += 2; // class
+    buffer += 4; // ttl
+
+    uint16_t rdlen = peek16(buffer);
+    buffer += 2;
+
+    if (buffer + rdlen > end)
+        buffer = end;
+    else
+        buffer += rdlen;
+}
+

--- a/src/response.hpp
+++ b/src/response.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 #include "message.hpp"
 
 
@@ -21,26 +25,57 @@ public:
     std::string asString() const;
 
     void setRCode(Code code) { m_rcode = code; }
-    void setName(const std::string& value) { m_name = value; }
-    void setType(const uint value) { m_type = value; }
-    void setClass(const uint value) { m_class = value; }
+
+    void setName(const std::string& value);
+    void setAnswerName(const std::string& value);
+    void setType(const uint value);
+    void setClass(const uint value);
     void setTtl(const ulong value) { m_ttl = value; }
     void setRdLength(const uint value) { m_rdLength = value; }
-    void setRdata(const std::string& value) { m_rdata = value; }
+    void setRdata(const std::string& value);
+    void setRdataBytes(const std::vector<uint8_t>& data);
+    void setMxPreference(uint16_t preference) { m_mxPreference = preference; }
 
-    const std::string& getRdata() { return m_rdata; }
-    const std::string& getName() const { return m_name; }
+    void clearAnswer();
+
+    const std::string& getQuestionName() const { return m_questionName; }
+    uint getQuestionType() const { return m_questionType; }
+    uint getQuestionClass() const { return m_questionClass; }
+
+    const std::string& getRdata() const { return m_rdata; }
+    const std::vector<uint8_t>& getRdataBytes() const { return m_rdataBinary; }
+    const std::vector<std::string>& getTxtStrings() const { return m_txtStrings; }
+    uint16_t getMxPreference() const { return m_mxPreference; }
+    const std::string& getName() const { return m_answerName; }
+    uint getType() const { return m_answerType; }
+    uint getClass() const { return m_answerClass; }
     
 private:
-    std::string m_name;
-    uint m_type;
-    uint m_class;
+    std::string m_questionName;
+    uint m_questionType;
+    uint m_questionClass;
+
+    std::string m_answerName;
+    uint m_answerType;
+    uint m_answerClass;
     ulong m_ttl;
     uint m_rdLength;
     std::string m_rdata;
+    std::vector<uint8_t> m_rdataBinary;
+    std::vector<std::string> m_txtStrings;
+    uint16_t m_mxPreference;
 
     void decode_domain(const char*& buffer, std::string& domain, const char* begin, const char* end);
     void code_domain(char*& buffer, const std::string& domain);
+
+    void parse_rdata(uint16_t type, const char* data, uint16_t length,
+                     const char* begin, const char* end);
+    std::vector<uint8_t> build_rdata() const;
+    std::vector<uint8_t> encode_domain_rdata(const std::string& domain) const;
+    std::vector<uint8_t> encode_txt_rdata(const std::string& text) const;
+    std::vector<uint8_t> encode_mx_rdata(uint16_t preference, const std::string& exchange) const;
+    std::vector<uint8_t> encode_address_rdata(int family, const std::string& address) const;
+    void skip_record(const char*& buffer, const char* begin, const char* end);
 };
 
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -273,41 +273,73 @@ void Server::handleQuery(const Query& query, Response& response)
 
     // std::cout << "domainName " << domainName << std::endl;
 
+    response.setID(query.getID());
+    response.setRecursionDesired(query.isRecursionDesired());
+    response.setName(query.getQName());
+    response.setType(query.getQType());
+    response.setClass(query.getQClass());
+    response.setTtl(0);
+    response.setQdCount(1);
+    response.setNsCount(0);
+    response.setArCount(0);
+
     if (domainName.empty())
     {
-        // cout << "[-] Domain not in scope !" << endl;
-
         dns::debug::log(
             "Server::handleQuery",
             "Domain '" + qName + "' not in scope; sending NameError");
 
-        response.setID( query.getID() );
-        response.setName( query.getQName() );
-        response.setType( query.getQType() );
-        response.setClass( query.getQClass() );
+        response.clearAnswer();
+        response.setAnCount(0);
         response.setRCode(Response::NameError);
-        response.setRdLength(1); // null label
     }
     else
     {
-        // cout << "[+] Domain in scope !" << endl;
-
         dns::debug::log(
             "Server::handleQuery",
             "Responding with payload '" + domainName + "' (" +
                 std::to_string(static_cast<unsigned long long>(domainName.size())) +
                 " bytes)");
 
-        response.setRCode(Response::Ok);
-        response.setRdLength(domainName.size()+2); // + initial label length & null label
-
-        response.setID( query.getID() );
-        response.setQdCount(1);
         response.setAnCount(1);
-        response.setName( query.getQName() );
-        response.setType( query.getQType() );
-        response.setClass( query.getQClass() );
-        response.setRdata(domainName);
+        response.setRCode(Response::Ok);
+        response.setMxPreference(0);
+
+        switch (query.getQType())
+        {
+            case 1: // A
+            {
+                std::string hex = domainName;
+                if (hex.size() < 8)
+                    hex.append(8 - hex.size(), '0');
+                if (hex.size() > 8)
+                    hex.resize(8);
+                response.setRdata(hex);
+                break;
+            }
+            case 28: // AAAA
+            {
+                std::string hex = domainName;
+                if (hex.size() < 32)
+                    hex.append(32 - hex.size(), '0');
+                if (hex.size() > 32)
+                    hex.resize(32);
+                response.setRdata(hex);
+                break;
+            }
+            case 15: // MX
+                response.setRdata(domainName);
+                break;
+            case 5:  // CNAME
+            case 2:  // NS
+            case 12: // PTR
+                response.setRdata(domainName);
+                break;
+            case 16: // TXT
+            default:
+                response.setRdata(domainName);
+                break;
+        }
     }
 
     // text = "Resolver::process()";

--- a/tests/dns_test.cpp
+++ b/tests/dns_test.cpp
@@ -47,10 +47,12 @@ int main() {
 
     Response response;
     response.setRCode(Response::Ok);
-    response.setRdLength(serverHex.size()+2);
     response.setID(query.getID());
+    response.setRecursionDesired(query.isRecursionDesired());
     response.setQdCount(1);
     response.setAnCount(1);
+    response.setNsCount(0);
+    response.setArCount(0);
     response.setName(query.getQName());
     response.setType(query.getQType());
     response.setClass(query.getQClass());

--- a/tests/response_decode_test.cpp
+++ b/tests/response_decode_test.cpp
@@ -6,31 +6,136 @@
 using namespace dns;
 
 int main() {
-    // Compressed DNS response for TXT record of example.com with "test" as data
-    const unsigned char packet[] = {
-        0x00,0x00,  // ID
+    // TXT record carrying "test"
+    const unsigned char txtPacket[] = {
+        0x00,0x01,  // ID
         0x81,0x80,  // Flags
         0x00,0x01,  // QDCOUNT
         0x00,0x01,  // ANCOUNT
         0x00,0x00,  // NSCOUNT
         0x00,0x00,  // ARCOUNT
-        // Question section: example.com
         0x07,'e','x','a','m','p','l','e',
         0x03,'c','o','m',0x00,
-        0x00,0x10,  // QTYPE=TXT
-        0x00,0x01,  // QCLASS=IN
-        // Answer section: name pointer to offset 12 (0xC00C)
+        0x00,0x10,
+        0x00,0x01,
         0xC0,0x0C,
-        0x00,0x10,  // TYPE=TXT
-        0x00,0x01,  // CLASS=IN
-        0x00,0x00,0x00,0x00,  // TTL
-        0x00,0x04,  // RDLENGTH (length of text only, as expected by decoder)
-        0x04,'t','e','s','t' // TXT length and data
+        0x00,0x10,
+        0x00,0x01,
+        0x00,0x00,0x00,0x3C,
+        0x00,0x05,
+        0x04,'t','e','s','t'
     };
 
-    Response resp;
-    resp.decode(reinterpret_cast<const char*>(packet), sizeof(packet));
-    assert(resp.getName() == "example.com");
-    assert(resp.getRdata() == "test");
+    Response respTxt;
+    respTxt.decode(reinterpret_cast<const char*>(txtPacket), sizeof(txtPacket));
+    assert(respTxt.getName() == "example.com");
+    assert(respTxt.getRdata() == "test");
+
+    // CNAME record mapping alias.example.com -> payload.example.com
+    const unsigned char cnamePacket[] = {
+        0x12,0x34,
+        0x81,0x80,
+        0x00,0x01,
+        0x00,0x01,
+        0x00,0x00,
+        0x00,0x00,
+        0x05,'a','l','i','a','s',
+        0x07,'e','x','a','m','p','l','e',
+        0x03,'c','o','m',0x00,
+        0x00,0x05,
+        0x00,0x01,
+        0xC0,0x0C,
+        0x00,0x05,
+        0x00,0x01,
+        0x00,0x00,0x00,0x3C,
+        0x00,0x15,
+        0x07,'p','a','y','l','o','a','d',
+        0x07,'e','x','a','m','p','l','e',
+        0x03,'c','o','m',0x00
+    };
+
+    Response respCname;
+    respCname.decode(reinterpret_cast<const char*>(cnamePacket), sizeof(cnamePacket));
+    assert(respCname.getName() == "alias.example.com");
+    assert(respCname.getRdata() == "payload.example.com");
+
+    // MX record with preference 10 and exchange payload.example.com
+    const unsigned char mxPacket[] = {
+        0x20,0x20,
+        0x81,0x80,
+        0x00,0x01,
+        0x00,0x01,
+        0x00,0x00,
+        0x00,0x00,
+        0x07,'e','x','a','m','p','l','e',
+        0x03,'c','o','m',0x00,
+        0x00,0x0F,
+        0x00,0x01,
+        0xC0,0x0C,
+        0x00,0x0F,
+        0x00,0x01,
+        0x00,0x00,0x00,0x0A,
+        0x00,0x17,
+        0x00,0x0A,
+        0x07,'p','a','y','l','o','a','d',
+        0x07,'e','x','a','m','p','l','e',
+        0x03,'c','o','m',0x00
+    };
+
+    Response respMx;
+    respMx.decode(reinterpret_cast<const char*>(mxPacket), sizeof(mxPacket));
+    assert(respMx.getName() == "example.com");
+    assert(respMx.getMxPreference() == 10);
+    assert(respMx.getRdata() == "payload.example.com");
+
+    // A record with address 192.0.2.1 (hex C0000201)
+    const unsigned char aPacket[] = {
+        0x33,0x33,
+        0x81,0x80,
+        0x00,0x01,
+        0x00,0x01,
+        0x00,0x00,
+        0x00,0x00,
+        0x07,'e','x','a','m','p','l','e',
+        0x03,'c','o','m',0x00,
+        0x00,0x01,
+        0x00,0x01,
+        0xC0,0x0C,
+        0x00,0x01,
+        0x00,0x01,
+        0x00,0x00,0x00,0x78,
+        0x00,0x04,
+        0xC0,0x00,0x02,0x01
+    };
+
+    Response respA;
+    respA.decode(reinterpret_cast<const char*>(aPacket), sizeof(aPacket));
+    assert(respA.getRdata() == "C0000201");
+
+    // AAAA record with address 2001:db8::1 (hex 20010DB8000000000000000000000001)
+    const unsigned char aaaaPacket[] = {
+        0x44,0x44,
+        0x81,0x80,
+        0x00,0x01,
+        0x00,0x01,
+        0x00,0x00,
+        0x00,0x00,
+        0x07,'e','x','a','m','p','l','e',
+        0x03,'c','o','m',0x00,
+        0x00,0x1C,
+        0x00,0x01,
+        0xC0,0x0C,
+        0x00,0x1C,
+        0x00,0x01,
+        0x00,0x00,0x00,0x01,
+        0x00,0x10,
+        0x20,0x01,0x0D,0xB8,0x00,0x00,0x00,0x00,
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x01
+    };
+
+    Response respAaaa;
+    respAaaa.decode(reinterpret_cast<const char*>(aaaaPacket), sizeof(aaaaPacket));
+    assert(respAaaa.getRdata() == "20010DB8000000000000000000000001");
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- fix DNS header serialization to keep the RD flag and response code in sync with the query metadata
- rewrite the response encoder/decoder to safely handle TXT, CNAME, MX, A and AAAA payloads and keep question/answer counters consistent
- update the server/tests and add a `publicDnsClient` helper plus README instructions for exercising the library against public resolvers

## Testing
- `cmake --build build`
- `./build/tests/messageTest`
- `./build/tests/responseDecodeTest`
- `./build/tests/utilsTest`
- `./build/tests/testsDns`
- `./build/tests/interleavedTest`


------
https://chatgpt.com/codex/tasks/task_e_68d100a82b608325ac485b77cb7daefa