### PR TITLE
Handle EDNS TXT fragmentation limits

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cctype>
+#include <cstdint>
 #include <string_view>
 #include <errno.h>
 #ifdef __linux__
@@ -14,6 +15,11 @@
 
 #include "client.hpp"
 #include "debugLog.hpp"
+
+namespace
+{
+constexpr uint16_t kDefaultClientUdpPayload = 4096;
+}
 
 using namespace std;
 using namespace dns;
@@ -88,7 +94,12 @@ void Client::sendMessage(const std::string& msg)
     query.setQdCount(1);
     query.setAnCount(0);
     query.setNsCount(0);
-    query.setArCount(0);
+    query.resetEdns();
+    query.enableEdns(kDefaultClientUdpPayload);
+    query.setArCount(1);
+    query.setEdnsVersion(0);
+    query.setEdnsExtendedRcode(0);
+    query.setEdnsFlags(0);
 
     dns::debug::log("Client::sendMessage", "Preparing transmission to DNS server " + m_dnsServerAdd + ":" + std::to_string(m_port));
 
@@ -334,7 +345,12 @@ std::string Client::requestMessage()
     query.setQdCount(1);
     query.setAnCount(0);
     query.setNsCount(0);
-    query.setArCount(0);
+    query.resetEdns();
+    query.enableEdns(kDefaultClientUdpPayload);
+    query.setArCount(1);
+    query.setEdnsVersion(0);
+    query.setEdnsExtendedRcode(0);
+    query.setEdnsFlags(0);
 
     dns::debug::log("Client::requestMessage", "Preparing transmission to DNS server " + m_dnsServerAdd + ":" + std::to_string(m_port));
 

--- a/src/dns.cpp
+++ b/src/dns.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <limits>
 #include <string_view>
 
 #include "nlohmann/json.hpp"
@@ -13,6 +14,44 @@
 
 using namespace std;
 using namespace dns;
+
+namespace
+{
+constexpr size_t kTxtResponseSafetyMargin = 512;
+
+size_t computeMaxHexPayload(size_t udpPayload)
+{
+    if (udpPayload <= kTxtResponseSafetyMargin)
+        return 0;
+
+    size_t budget = udpPayload - kTxtResponseSafetyMargin;
+    size_t maxHex = budget;
+    while (maxHex > 0)
+    {
+        size_t txtOverhead = (maxHex + 254) / 255;
+        if (maxHex + txtOverhead <= budget)
+            return maxHex;
+        --maxHex;
+    }
+    return 0;
+}
+
+int computeTxtJsonLimit(size_t udpPayload)
+{
+    size_t maxHex = computeMaxHexPayload(udpPayload);
+    if (maxHex == 0)
+        return 0;
+
+    size_t allowedJson = maxHex / 2;
+    if (allowedJson == 0)
+        return 0;
+
+    if (allowedJson > static_cast<size_t>(std::numeric_limits<int>::max()))
+        return std::numeric_limits<int>::max();
+
+    return static_cast<int>(allowedJson);
+}
+} // namespace
 
 using json = nlohmann::json;
 
@@ -97,7 +136,7 @@ void Dns::setMsg(const std::string& msg, const std::string& clientId)
  *       from m_msgToSend for the given client.
  */
 
-void Dns::splitPacket(int qType, const std::string& clientId)
+void Dns::splitPacket(int qType, const std::string& clientId, uint16_t udpPayloadHint)
 {
     if(m_msgToSend[clientId].empty())
         return;
@@ -126,8 +165,27 @@ void Dns::splitPacket(int qType, const std::string& clientId)
             break;
         case 16: // TXT
         default:
+        {
             maxMessageSize = m_maxMessageSize;
+            if (udpPayloadHint > 0)
+            {
+                int txtLimit = computeTxtJsonLimit(udpPayloadHint);
+                if (txtLimit > 0)
+                {
+                    int originalLimit = maxMessageSize;
+                    maxMessageSize = std::max(maxMessageSize, txtLimit);
+                    if (maxMessageSize != originalLimit)
+                    {
+                        dns::debug::log(
+                            "Dns::splitPacket",
+                            "Expanded TXT fragment capacity using EDNS UDP payload hint " +
+                                std::to_string(udpPayloadHint) +
+                                " -> max JSON size " + std::to_string(maxMessageSize));
+                    }
+                }
+            }
             break;
+        }
     }
 
     dns::debug::log("Dns::splitPacket",

--- a/src/dns.hpp
+++ b/src/dns.hpp
@@ -43,7 +43,7 @@ protected:
     std::pair<std::string, std::string> getMsg();
 
     void handleDataReceived(const std::string& rdata, const std::string& clientId);
-    void splitPacket(int qType, const std::string& clientId);
+    void splitPacket(int qType, const std::string& clientId, uint16_t udpPayloadHint = 0);
     
     std::string m_domainToResolve;
     int m_maxMessageSize;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <sstream>
 #include <iomanip>
+#include <algorithm>
+#include <cstring>
 
 #ifdef __linux__
 
@@ -38,6 +40,8 @@ Message::Message(Type type)
     m_anCount=0;
     m_nsCount=0;
     m_arCount=0;
+
+    resetEdns();
 }
 
 
@@ -148,7 +152,7 @@ int Message::get32bits(const char*& buffer)
 }
 
 
-void Message::put16bits(char*& buffer, uint value)  
+void Message::put16bits(char*& buffer, uint value) const
 {
     buffer[0] = (value & 0xFF00) >> 8;
     buffer[1] = value & 0xFF;
@@ -156,11 +160,141 @@ void Message::put16bits(char*& buffer, uint value)
 }
 
 
-void Message::put32bits(char*& buffer, ulong value)  
+void Message::put32bits(char*& buffer, ulong value) const
 {
     buffer[0] = (value >> 24) & 0xFF;
     buffer[1] = (value >> 16) & 0xFF;
     buffer[2] = (value >> 8) & 0xFF;
     buffer[3] = value & 0xFF;
     buffer += 4;
+}
+
+void Message::resetEdns()
+{
+    m_edns.present = false;
+    m_edns.udpPayloadSize = 512;
+    m_edns.extendedRcode = 0;
+    m_edns.version = 0;
+    m_edns.flags = 0;
+    m_edns.data.clear();
+}
+
+void Message::enableEdns(uint16_t udpPayloadSize)
+{
+    m_edns.present = true;
+    m_edns.udpPayloadSize = udpPayloadSize;
+    if (m_arCount == 0)
+        m_arCount = 1;
+}
+
+void Message::disableEdns()
+{
+    resetEdns();
+}
+
+void Message::skipDomain(const char*& buffer, const char* end)
+{
+    while (buffer < end)
+    {
+        uint8_t length = static_cast<uint8_t>(*buffer++);
+        if (length == 0)
+            return;
+
+        if ((length & 0xC0) == 0xC0)
+        {
+            if (buffer < end)
+                ++buffer;
+            return;
+        }
+
+        if (buffer + length > end)
+        {
+            buffer = end;
+            return;
+        }
+
+        buffer += length;
+    }
+}
+
+void Message::encodeEdns(char*& buffer) const
+{
+    if (!m_edns.present)
+        return;
+
+    *buffer++ = 0;
+    put16bits(buffer, 41);
+    put16bits(buffer, m_edns.udpPayloadSize);
+
+    uint32_t ttl = (static_cast<uint32_t>(m_edns.extendedRcode) << 24) |
+                   (static_cast<uint32_t>(m_edns.version) << 16) |
+                   static_cast<uint32_t>(m_edns.flags);
+    put32bits(buffer, ttl);
+
+    uint16_t rdlength = static_cast<uint16_t>(m_edns.data.size());
+    put16bits(buffer, rdlength);
+    if (rdlength > 0)
+    {
+        std::memcpy(buffer, m_edns.data.data(), rdlength);
+        buffer += rdlength;
+    }
+}
+
+bool Message::decodeEdns(const char*& buffer, const char* end)
+{
+    skipDomain(buffer, end);
+    if (buffer >= end)
+    {
+        buffer = end;
+        return false;
+    }
+
+    if (buffer + 2 > end)
+    {
+        buffer = end;
+        return false;
+    }
+    uint16_t type = static_cast<uint16_t>(get16bits(buffer));
+
+    if (buffer + 2 > end)
+    {
+        buffer = end;
+        return false;
+    }
+    uint16_t udpPayload = static_cast<uint16_t>(get16bits(buffer));
+
+    if (buffer + 4 > end)
+    {
+        buffer = end;
+        return false;
+    }
+    uint32_t ttl = static_cast<uint32_t>(get32bits(buffer));
+
+    if (buffer + 2 > end)
+    {
+        buffer = end;
+        return false;
+    }
+    uint16_t rdlength = static_cast<uint16_t>(get16bits(buffer));
+
+    size_t remaining = buffer < end ? static_cast<size_t>(end - buffer) : 0U;
+    size_t available = std::min(static_cast<size_t>(rdlength), remaining);
+
+    if (type == 41)
+    {
+        m_edns.present = true;
+        m_edns.udpPayloadSize = udpPayload;
+        m_edns.extendedRcode = static_cast<uint8_t>((ttl >> 24) & 0xFF);
+        m_edns.version = static_cast<uint8_t>((ttl >> 16) & 0xFF);
+        m_edns.flags = static_cast<uint16_t>(ttl & 0xFFFF);
+        m_edns.data.assign(buffer, buffer + available);
+    }
+
+    buffer += available;
+    if (available < rdlength)
+    {
+        buffer = end;
+    }
+
+    return type == 41;
 }

--- a/src/message.hpp
+++ b/src/message.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
+#include <vector>
 
 namespace dns 
 {
@@ -65,6 +67,21 @@ public:
     void setNsCount(uint count) { m_nsCount = count; }
     void setArCount(uint count) { m_arCount = count; }
 
+    void resetEdns();
+    void enableEdns(uint16_t udpPayloadSize = 4096);
+    void disableEdns();
+    bool hasEdns() const { return m_edns.present; }
+    void setEdnsUdpPayloadSize(uint16_t value) { m_edns.udpPayloadSize = value; }
+    uint16_t getEdnsUdpPayloadSize() const { return m_edns.udpPayloadSize; }
+    void setEdnsExtendedRcode(uint8_t value) { m_edns.extendedRcode = value; }
+    uint8_t getEdnsExtendedRcode() const { return m_edns.extendedRcode; }
+    void setEdnsVersion(uint8_t value) { m_edns.version = value; }
+    uint8_t getEdnsVersion() const { return m_edns.version; }
+    void setEdnsFlags(uint16_t value) { m_edns.flags = value; }
+    uint16_t getEdnsFlags() const { return m_edns.flags; }
+    void setEdnsOptions(const std::vector<uint8_t>& options) { m_edns.data = options; }
+    const std::vector<uint8_t>& getEdnsOptions() const { return m_edns.data; }
+
 protected:
     Message(Type type);
     ~Message();
@@ -86,6 +103,18 @@ protected:
     uint m_nsCount;
     uint m_arCount;
 
+    struct EdnsFields
+    {
+        bool present;
+        uint16_t udpPayloadSize;
+        uint8_t extendedRcode;
+        uint8_t version;
+        uint16_t flags;
+        std::vector<uint8_t> data;
+    };
+
+    EdnsFields m_edns;
+
     virtual std::string asString() const ;
 
     void decode_hdr(const char* buffer) ;
@@ -94,11 +123,15 @@ protected:
     int get16bits(const char*& buffer) ;
     int get32bits(const char*& buffer) ;
 
-    void put16bits(char*& buffer, uint value) ;
-    void put32bits(char*& buffer, ulong value) ;
+    void put16bits(char*& buffer, uint value) const;
+    void put32bits(char*& buffer, ulong value) const;
 
     void log_buffer(const char* buffer, int size) ;
-    
+
+    void skipDomain(const char*& buffer, const char* end);
+    void encodeEdns(char*& buffer) const;
+    bool decodeEdns(const char*& buffer, const char* end);
+
 private:
     static const uint QR_MASK = 0x8000;
     static const uint OPCODE_MASK = 0x7800;

--- a/src/query.cpp
+++ b/src/query.cpp
@@ -38,7 +38,7 @@ string Query::asString() const
 }
 
 
-int Query::code(char* buffer)  
+int Query::code(char* buffer)
 {
     char* bufferBegin = buffer;
 
@@ -50,6 +50,11 @@ int Query::code(char* buffer)
     put16bits(buffer, m_qType);
     put16bits(buffer, m_qClass);
 
+    if (hasEdns())
+    {
+        encodeEdns(buffer);
+    }
+
     int size = buffer - bufferBegin;
 
     return size;
@@ -58,15 +63,23 @@ int Query::code(char* buffer)
 
 void Query::decode(const char* buffer, int size)  
 {
-    // log_buffer(buffer, size);
+    const char* begin = buffer;
+    const char* end = buffer + size;
 
     decode_hdr(buffer);
-    buffer += HDR_OFFSET;
-    
-    decode_qname(buffer);
 
-    m_qType = get16bits(buffer);
-    m_qClass = get16bits(buffer);
+    const char* cursor = begin + HDR_OFFSET;
+
+    decode_qname(cursor);
+
+    m_qType = get16bits(cursor);
+    m_qClass = get16bits(cursor);
+
+    resetEdns();
+    for (uint i = 0; i < m_arCount && cursor < end; ++i)
+    {
+        decodeEdns(cursor, end);
+    }
 }
 
 

--- a/src/response.cpp
+++ b/src/response.cpp
@@ -177,6 +177,8 @@ void Response::decode(const char* buffer, int size)
     m_answerClass = 0;
     m_ttl = 0;
 
+    resetEdns();
+
     if (size < static_cast<int>(HDR_OFFSET))
         return;
 
@@ -247,7 +249,12 @@ void Response::decode(const char* buffer, int size)
 
     for (uint i = 0; i < m_arCount && cursor < end; ++i)
     {
-        skip_record(cursor, begin, end);
+        const char* recordStart = cursor;
+        if (!decodeEdns(cursor, end))
+        {
+            cursor = recordStart;
+            skip_record(cursor, begin, end);
+        }
     }
 }
 
@@ -282,6 +289,11 @@ int Response::code(char* buffer)
             std::memcpy(buffer, rdata.data(), rdata.size());
             buffer += rdata.size();
         }
+    }
+
+    if (hasEdns())
+    {
+        encodeEdns(buffer);
     }
 
     int size = static_cast<int>(buffer - bufferBegin);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cctype>
+#include <cstdint>
 #include <string_view>
 
 #include <errno.h>
@@ -21,6 +22,8 @@
 
 namespace
 {
+constexpr uint16_t kMaxServerUdpPayload = 4096;
+
 std::string endpointToString(const sockaddr_in& addr)
 {
     char buffer[INET_ADDRSTRLEN] = {0};
@@ -428,6 +431,11 @@ void Server::prepareResponse(const Query& query, Response& response)
     string qName = query.getQName();
 
     string dataToSend = "";
+    uint16_t negotiatedSize = 0;
+    if (query.hasEdns())
+    {
+        negotiatedSize = std::min<uint16_t>(query.getEdnsUdpPayloadSize(), kMaxServerUdpPayload);
+    }
     if (endsWith(qName, m_domainToResolve))
     {
         //data1.data2.data3.id.domain
@@ -452,7 +460,7 @@ void Server::prepareResponse(const Query& query, Response& response)
         // ask data
         if(qName.contains(m_secretKeyClientAskData))
         {
-            splitPacket(query.getQType(), id);
+            splitPacket(query.getQType(), id, negotiatedSize);
             
             // data available
             if(!m_msgQueue[id].empty())
@@ -503,7 +511,25 @@ void Server::prepareResponse(const Query& query, Response& response)
     response.setTtl(0);
     response.setQdCount(1);
     response.setNsCount(0);
-    response.setArCount(0);
+    response.resetEdns();
+
+    if (negotiatedSize > 0)
+    {
+        response.enableEdns(negotiatedSize);
+        response.setArCount(1);
+        response.setEdnsVersion(0);
+        response.setEdnsExtendedRcode(0);
+        response.setEdnsFlags(query.getEdnsFlags() & 0x8000U);
+
+        dns::debug::log(
+            "Server::prepareResponse",
+            "Negotiated EDNS UDP payload size=" + std::to_string(negotiatedSize));
+    }
+    else
+    {
+        response.disableEdns();
+        response.setArCount(0);
+    }
 
     if (dataToSend.empty())
     {


### PR DESCRIPTION
## Summary
- expand `Dns::splitPacket` to accept an optional UDP payload hint and grow TXT fragment capacity based on EDNS negotiation
- compute a safe TXT JSON size from the negotiated payload and log when the limit increases
- plumb the negotiated EDNS UDP size through `Server::prepareResponse` so TXT replies can take advantage of the larger budget

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68d506e8879c8325befbd9b7a535d0bb