### PR TITLE
Fix hex encoding and add round trip test

### DIFF
--- a/src/dnsPacker.cpp
+++ b/src/dnsPacker.cpp
@@ -10,17 +10,15 @@ namespace dns
 {
 
 
-std::string stringToHex(const std::string& input) 
+std::string stringToHex(const std::string& input)
 {
-    std::string result = "";
-    for (char c : input) 
+    std::ostringstream oss;
+    oss << std::hex << std::uppercase;
+    for (unsigned char c : input)
     {
-        int ascii = static_cast<int>(c);
-        std::stringstream ss;
-        ss << std::hex << std::uppercase << ascii;
-        result += ss.str();
+        oss << std::setw(2) << std::setfill('0') << static_cast<int>(c);
     }
-    return result;
+    return oss.str();
 }
 
 

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -27,5 +27,11 @@ int main() {
     assert(a.size() == 8);
     assert(b.size() == 8);
     assert(a != b);
+
+    const std::string binaryData("\0\x01\x05\x0A\x10\x1F\x7F\x80\xFF", 9);
+    std::string hex = stringToHex(binaryData);
+    assert(hex.size() == binaryData.size() * 2);
+    std::string roundTrip = hexToString(hex);
+    assert(roundTrip == binaryData);
     return 0;
 }


### PR DESCRIPTION
## Summary
- ensure `stringToHex` always emits two-character uppercase hex for each byte
- extend the utils test to round-trip binary data, guarding against regressions

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68d7821548e483258bd6b5c134cceb24