### PR TITLE
Avoid trailing dot in 62-character DNS fragments

### DIFF
--- a/src/dnsPacker.cpp
+++ b/src/dnsPacker.cpp
@@ -38,20 +38,25 @@ std::string hexToString(const std::string& hex)
 }
 
 
-std::string addDotEvery62Chars(const std::string& str) 
+std::string addDotEvery62Chars(const std::string& str)
 {
     std::string result;
     int count = 0;
 
-    for (char ch : str) 
+    for (char ch : str)
     {
         result.push_back(ch);
         count++;
-        if (count == 62) 
+        if (count == 62)
         {
             result.push_back('.');
             count = 0;
         }
+    }
+
+    if (!result.empty() && result.back() == '.')
+    {
+        result.pop_back();
     }
 
     return result;

--- a/tests/dns_test.cpp
+++ b/tests/dns_test.cpp
@@ -5,6 +5,7 @@
 
 #include "dns.hpp"
 #include "dnsPacker.hpp"
+#include "query.hpp"
 
 using namespace dns;
 
@@ -85,6 +86,33 @@ int main()
     auto [clientServerId, clientReceived] = clientHarness.takeComplete();
     assert(clientServerId == serverIdentity);
     assert(clientReceived == serverMsg);
+
+    // Regression test: ensure QNAME encoding handles 62-byte labels without
+    // introducing an empty label between the fragment and the domain.
+    const std::string sixtyTwoHex(62, 'A');
+    std::string qnameData = addDotEvery62Chars(sixtyTwoHex);
+    assert(!qnameData.empty());
+    assert(qnameData.back() != '.');
+
+    Query encodedQuery;
+    encodedQuery.setID(0);
+    encodedQuery.setQdCount(1);
+    encodedQuery.setAnCount(0);
+    encodedQuery.setNsCount(0);
+    encodedQuery.setArCount(0);
+    encodedQuery.setQName(qnameData + "." + domain);
+    encodedQuery.setQType(5);
+    encodedQuery.setQClass(1);
+
+    char buffer[512];
+    int encodedLength = encodedQuery.code(buffer);
+
+    Query decodedQuery;
+    decodedQuery.decode(buffer, encodedLength);
+
+    assert(decodedQuery.getQName() == qnameData + "." + domain);
+    assert(decodedQuery.getQType() == 5);
+    assert(decodedQuery.getQClass() == 1);
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- prevent `addDotEvery62Chars` from leaving a trailing label separator when the input length is an exact multiple of 62
- add a regression test that encodes/decodes a 62-character fragment and verifies the QNAME, QTYPE, and QCLASS remain intact

## Testing
- cmake -S . -B build
- cmake --build build
- ./build/tests/dnsTest

------
https://chatgpt.com/codex/tasks/task_e_68d78215b98c8325b1e8c26f4a794f51