### PR TITLE
Handle out-of-order DNS fragment assembly

### DIFF
--- a/src/dns.cpp
+++ b/src/dns.cpp
@@ -344,10 +344,58 @@ void Dns::handleDataReceived(const std::string& rdata, const std::string& client
             packet.id = session;
         if(packet.clientId.empty() && !clientId.empty())
             packet.clientId = clientId;
-        packet.data.append(payload);
-        packet.isFull = (k == n-1);
 
-        accumulatedSize = packet.data.size();
+        if (packet.expectedCount < 0)
+        {
+            packet.expectedCount = n;
+        }
+        else if (packet.expectedCount != n)
+        {
+            dns::debug::log(
+                "Dns::handleResponse",
+                "Fragment count mismatch for session '" + session +
+                    "' (expected " + std::to_string(packet.expectedCount) +
+                    ", got " + std::to_string(n) + ")");
+            packet.expectedCount = n;
+        }
+
+        packet.fragments[k] = payload;
+
+        accumulatedSize = 0;
+        for (const auto& fragment : packet.fragments)
+        {
+            accumulatedSize += fragment.second.size();
+        }
+
+        bool allPresent =
+            packet.expectedCount > 0 &&
+            packet.fragments.size() == static_cast<size_t>(packet.expectedCount);
+
+        if (allPresent)
+        {
+            int expectedIndex = 0;
+            for (const auto& entry : packet.fragments)
+            {
+                if (entry.first != expectedIndex)
+                {
+                    allPresent = false;
+                    break;
+                }
+                ++expectedIndex;
+            }
+        }
+
+        if (allPresent)
+        {
+            packet.data.clear();
+            packet.data.reserve(accumulatedSize);
+            for (const auto& entry : packet.fragments)
+            {
+                packet.data.append(entry.second);
+            }
+        }
+
+        packet.isFull = allPresent;
         packetFull = packet.isFull;
 
         m_moreMsgToGet = false;

--- a/src/dnsPacker.hpp
+++ b/src/dnsPacker.hpp
@@ -1,18 +1,21 @@
 #pragma once
 
+#include <algorithm>
 #include <cctype>
-#include <algorithm> 
+#include <map>
 
 
-namespace dns 
+namespace dns
 {
 
-struct Packet 
+struct Packet
 {
     std::string data;
-    bool isFull;
+    bool isFull = false;
     std::string id;
     std::string clientId;
+    int expectedCount = -1;
+    std::map<int, std::string> fragments;
 };
 
 // https://github.com/iagox86/dnscat2

--- a/tests/interleaved_messages_test.cpp
+++ b/tests/interleaved_messages_test.cpp
@@ -83,6 +83,8 @@ int main()
         }
     }
 
+    std::reverse(interleavedFragments.begin(), interleavedFragments.end());
+
     for (const auto& [clientId, payload] : interleavedFragments)
     {
         serverHarness.ingest(payload, clientId);


### PR DESCRIPTION
## Summary
- track incoming DNS fragments by index and remember the expected count before assembly
- mark packets as complete only when every fragment from 0..n-1 is present and rebuild the payload in order
- extend the interleaved test to deliver fragments in reverse order to cover out-of-order delivery

## Testing
- cmake -S . -B build
- cmake --build build
- ./tests/interleavedTest


------
https://chatgpt.com/codex/tasks/task_e_68d78216af3483258c2d43d19501aecb